### PR TITLE
MODLD-602: Updated TitleFieldRequest & TitleFieldResponse to avoid oneOf at the top level

### DIFF
--- a/src/main/java/org/folio/linked/data/configuration/json/ObjectMapperConfig.java
+++ b/src/main/java/org/folio/linked/data/configuration/json/ObjectMapperConfig.java
@@ -14,7 +14,7 @@ import org.folio.linked.data.domain.dto.InstanceRequestAllOfMap;
 import org.folio.linked.data.domain.dto.MarcRecord;
 import org.folio.linked.data.domain.dto.ResourceRequestField;
 import org.folio.linked.data.domain.dto.SourceRecordDomainEvent;
-import org.folio.linked.data.domain.dto.TitleFieldRequest;
+import org.folio.linked.data.domain.dto.TitleFieldRequestTitleInner;
 import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +38,7 @@ public class ObjectMapperConfig {
   private Module monographModule(ObjectMapper objectMapper, RequestProcessingExceptionBuilder exceptionBuilder) {
     return new SimpleModule()
       .addDeserializer(ResourceRequestField.class, new ResourceRequestFieldDeserializer(exceptionBuilder))
-      .addDeserializer(TitleFieldRequest.class, new TitleFieldRequestDeserializer(exceptionBuilder))
+      .addDeserializer(TitleFieldRequestTitleInner.class, new TitleFieldRequestDeserializer(exceptionBuilder))
       .addDeserializer(InstanceRequestAllOfMap.class, new InstanceRequestAllOfMapDeserializer(exceptionBuilder))
       .addDeserializer(SourceRecordDomainEvent.class, new SourceRecordDomainEventDeserializer(objectMapper));
   }

--- a/src/main/java/org/folio/linked/data/configuration/json/deserialization/title/TitleFieldRequestDeserializer.java
+++ b/src/main/java/org/folio/linked/data/configuration/json/deserialization/title/TitleFieldRequestDeserializer.java
@@ -11,26 +11,26 @@ import java.io.IOException;
 import java.util.Map;
 import org.folio.linked.data.domain.dto.ParallelTitleField;
 import org.folio.linked.data.domain.dto.PrimaryTitleField;
-import org.folio.linked.data.domain.dto.TitleFieldRequest;
+import org.folio.linked.data.domain.dto.TitleFieldRequestTitleInner;
 import org.folio.linked.data.domain.dto.VariantTitleField;
 import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.folio.linked.data.util.DtoDeserializer;
 
-public class TitleFieldRequestDeserializer extends JsonDeserializer<TitleFieldRequest> {
+public class TitleFieldRequestDeserializer extends JsonDeserializer<TitleFieldRequestTitleInner> {
 
-  private static final Map<String, Class<? extends TitleFieldRequest>> IDENDTITY_MAP = Map.of(
+  private static final Map<String, Class<? extends TitleFieldRequestTitleInner>> IDENDTITY_MAP = Map.of(
     TITLE.getUri(), PrimaryTitleField.class,
     PARALLEL_TITLE.getUri(), ParallelTitleField.class,
     VARIANT_TITLE.getUri(), VariantTitleField.class
   );
-  private final DtoDeserializer<TitleFieldRequest> dtoDeserializer;
+  private final DtoDeserializer<TitleFieldRequestTitleInner> dtoDeserializer;
 
   public TitleFieldRequestDeserializer(RequestProcessingExceptionBuilder exceptionBuilder) {
-    dtoDeserializer = new DtoDeserializer<>(TitleFieldRequest.class, IDENDTITY_MAP, exceptionBuilder);
+    dtoDeserializer = new DtoDeserializer<>(TitleFieldRequestTitleInner.class, IDENDTITY_MAP, exceptionBuilder);
   }
 
   @Override
-  public TitleFieldRequest deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
+  public TitleFieldRequestTitleInner deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
     return dtoDeserializer.deserialize(jp);
   }
 

--- a/src/main/java/org/folio/linked/data/mapper/dto/monograph/TopResourceMapperUnit.java
+++ b/src/main/java/org/folio/linked/data/mapper/dto/monograph/TopResourceMapperUnit.java
@@ -8,7 +8,7 @@ import java.util.Set;
 import org.folio.linked.data.domain.dto.PrimaryTitleField;
 import org.folio.linked.data.domain.dto.ResourceRequestDto;
 import org.folio.linked.data.domain.dto.ResourceResponseDto;
-import org.folio.linked.data.domain.dto.TitleFieldRequest;
+import org.folio.linked.data.domain.dto.TitleFieldRequestTitleInner;
 import org.folio.linked.data.mapper.dto.common.SingleResourceMapperUnit;
 
 public abstract class TopResourceMapperUnit implements SingleResourceMapperUnit {
@@ -23,7 +23,7 @@ public abstract class TopResourceMapperUnit implements SingleResourceMapperUnit 
     return SUPPORTED_PARENTS;
   }
 
-  protected List<String> getPrimaryMainTitles(List<TitleFieldRequest> titles) {
+  protected List<String> getPrimaryMainTitles(List<TitleFieldRequestTitleInner> titles) {
     if (isNull(titles)) {
       return new ArrayList<>();
     }

--- a/src/main/java/org/folio/linked/data/validation/dto/PrimaryTitleDtoValidator.java
+++ b/src/main/java/org/folio/linked/data/validation/dto/PrimaryTitleDtoValidator.java
@@ -8,13 +8,14 @@ import jakarta.validation.ConstraintValidatorContext;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.linked.data.domain.dto.PrimaryTitleField;
-import org.folio.linked.data.domain.dto.TitleFieldRequest;
+import org.folio.linked.data.domain.dto.TitleFieldRequestTitleInner;
 import org.folio.linked.data.validation.PrimaryTitleConstraint;
 
-public class PrimaryTitleDtoValidator implements ConstraintValidator<PrimaryTitleConstraint, List<TitleFieldRequest>> {
+public class PrimaryTitleDtoValidator implements
+  ConstraintValidator<PrimaryTitleConstraint, List<TitleFieldRequestTitleInner>> {
 
   @Override
-  public boolean isValid(List<TitleFieldRequest> titleFields, ConstraintValidatorContext context) {
+  public boolean isValid(List<TitleFieldRequestTitleInner> titleFields, ConstraintValidatorContext context) {
     if (isNull(titleFields)) {
       return true;
     }

--- a/src/main/resources/swagger.api/schema/resource/request/InstanceRequest.json
+++ b/src/main/resources/swagger.api/schema/resource/request/InstanceRequest.json
@@ -3,17 +3,11 @@
   "description": "Instance request DTO",
   "allOf": [
     {
+      "$ref": "title/TitleFieldRequest.json"
+    },
+    {
       "type": "object",
       "properties": {
-        "title": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "title/TitleFieldRequest.json"
-          },
-          "x-json-property": "http://bibfra.me/vocab/marc/title",
-          "x-field-extra-annotation": "@org.folio.linked.data.validation.PrimaryTitleConstraint"
-        },
         "production": {
           "type": "array",
           "items": {
@@ -208,8 +202,7 @@
             "$ref": "../common/IdField.json"
           }
         }
-      },
-      "required": ["title"]
+      }
     }
   ]
 }

--- a/src/main/resources/swagger.api/schema/resource/request/WorkRequest.json
+++ b/src/main/resources/swagger.api/schema/resource/request/WorkRequest.json
@@ -3,17 +3,11 @@
   "description": "Work request DTO",
   "allOf": [
     {
+      "$ref": "title/TitleFieldRequest.json"
+    },
+    {
       "type": "object",
       "properties": {
-        "title": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "title/TitleFieldRequest.json"
-          },
-          "x-json-property": "http://bibfra.me/vocab/marc/title",
-          "x-field-extra-annotation": "@org.folio.linked.data.validation.PrimaryTitleConstraint"
-        },
         "targetAudience": {
           "type": "array",
           "items": {
@@ -149,8 +143,7 @@
           },
           "x-json-property": "http://bibfra.me/vocab/scholar/dissertation"
         }
-      },
-      "required": ["title"]
+      }
     }
   ]
 }

--- a/src/main/resources/swagger.api/schema/resource/request/title/TitleFieldRequest.json
+++ b/src/main/resources/swagger.api/schema/resource/request/title/TitleFieldRequest.json
@@ -1,38 +1,54 @@
 {
-  "description": "A title of a resource.",
-  "oneOf": [
-    {
-      "type": "object",
-      "title": "PrimaryTitleField",
-      "properties": {
-        "PrimaryTitle": {
-          "type": "object",
-          "$ref": "schema/resource/common/title/PrimaryTitle.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/Title"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "title": "VariantTitleField",
-      "properties": {
-        "VariantTitle": {
-          "type": "object",
-          "$ref": "schema/resource/common/title/VariantTitle.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/VariantTitle"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "title": "ParallelTitleField",
-      "properties": {
-        "ParallelTitle": {
-          "type": "object",
-          "$ref": "schema/resource/common/title/ParallelTitle.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/ParallelTitle"
-        }
-      }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Title of the Work or Instance resource",
+  "properties": {
+    "title": {
+      "type": "array",
+      "description": "The title of the work or instance",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "PrimaryTitleField",
+            "properties": {
+              "PrimaryTitle": {
+                "type": "object",
+                "$ref": "../../common/title/PrimaryTitle.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/Title",
+                "description": "The primary title of the work or instance"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "VariantTitleField",
+            "properties": {
+              "VariantTitle": {
+                "type": "object",
+                "$ref": "../../common/title/VariantTitle.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/VariantTitle",
+                "description": "The variant title of the work or instance"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "ParallelTitleField",
+            "properties": {
+              "ParallelTitle": {
+                "type": "object",
+                "$ref": "../../common/title/ParallelTitle.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/ParallelTitle",
+                "description": "The parallel title of the work or instance"
+              }
+            }
+          }
+        ]
+      },
+      "x-json-property": "http://bibfra.me/vocab/marc/title",
+      "x-field-extra-annotation": "@org.folio.linked.data.validation.PrimaryTitleConstraint"
     }
-  ]
+  },
+  "required": ["title"]
 }

--- a/src/main/resources/swagger.api/schema/resource/response/InstanceResponse.json
+++ b/src/main/resources/swagger.api/schema/resource/response/InstanceResponse.json
@@ -6,16 +6,11 @@
       "$ref": "../common/IdField.json"
     },
     {
+      "$ref": "title/TitleFieldResponse.json"
+    },
+    {
       "type": "object",
       "properties": {
-        "title": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "title/TitleFieldResponse.json"
-          },
-          "x-json-property": "http://bibfra.me/vocab/marc/title"
-        },
         "production": {
           "type": "array",
           "items": {

--- a/src/main/resources/swagger.api/schema/resource/response/WorkResponse.json
+++ b/src/main/resources/swagger.api/schema/resource/response/WorkResponse.json
@@ -6,16 +6,11 @@
       "$ref": "../common/IdField.json"
     },
     {
+      "$ref": "title/TitleFieldResponse.json"
+    },
+    {
       "type": "object",
       "properties": {
-        "title": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "title/TitleFieldResponse.json"
-          },
-          "x-json-property": "http://bibfra.me/vocab/marc/title"
-        },
         "targetAudience": {
           "type": "array",
           "items": {

--- a/src/main/resources/swagger.api/schema/resource/response/title/TitleFieldResponse.json
+++ b/src/main/resources/swagger.api/schema/resource/response/title/TitleFieldResponse.json
@@ -1,38 +1,52 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Title of the Work or Instance resource",
-  "oneOf": [
-    {
-      "type": "object",
-      "title": "PrimaryTitleFieldResponse",
-      "properties": {
-        "PrimaryTitle": {
-          "type": "object",
-          "$ref": "schema/resource/response/title/PrimaryTitleResponse.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/Title"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "title": "VariantTitleFieldResponse",
-      "properties": {
-        "VariantTitle": {
-          "type": "object",
-          "$ref": "schema/resource/response/title/VariantTitleResponse.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/VariantTitle"
-        }
-      }
-    },
-    {
-      "type": "object",
-      "title": "ParallelTitleFieldResponse",
-      "properties": {
-        "ParallelTitle": {
-          "type": "object",
-          "$ref": "schema/resource/response/title/ParallelTitleResponse.json",
-          "x-json-property": "http://bibfra.me/vocab/marc/ParallelTitle"
-        }
-      }
+  "properties": {
+    "title": {
+      "type": "array",
+      "description": "The title of the work or instance",
+      "items": {
+        "type": "object",
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "PrimaryTitleFieldResponse",
+            "properties": {
+              "PrimaryTitle": {
+                "type": "object",
+                "$ref": "PrimaryTitleResponse.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/Title",
+                "description": "The primary title of the work or instance"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "VariantTitleFieldResponse",
+            "properties": {
+              "VariantTitle": {
+                "type": "object",
+                "$ref": "VariantTitleResponse.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/VariantTitle",
+                "description": "The variant title of the work or instance"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "title": "ParallelTitleFieldResponse",
+            "properties": {
+              "ParallelTitle": {
+                "type": "object",
+                "$ref": "ParallelTitleResponse.json",
+                "x-json-property": "http://bibfra.me/vocab/marc/ParallelTitle",
+                "description": "The parallel title of the work or instance"
+              }
+            }
+          }
+        ]
+      },
+      "x-json-property": "http://bibfra.me/vocab/marc/title"
     }
-  ]
+  }
 }

--- a/src/test/java/org/folio/linked/data/test/TestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/TestUtil.java
@@ -37,7 +37,7 @@ import org.folio.linked.data.configuration.ErrorResponseConfig;
 import org.folio.linked.data.configuration.json.ObjectMapperConfig;
 import org.folio.linked.data.domain.dto.InstanceResponseAllOfMap;
 import org.folio.linked.data.domain.dto.ResourceResponseField;
-import org.folio.linked.data.domain.dto.TitleFieldResponse;
+import org.folio.linked.data.domain.dto.TitleFieldResponseTitleInner;
 import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.test.json.InstanceResponseAllOfMapDeserializer;
@@ -72,7 +72,7 @@ public class TestUtil {
   static {
     OBJECT_MAPPER.registerModule(new SimpleModule()
       .addDeserializer(ResourceResponseField.class, new ResourceResponseFieldDeserializer())
-      .addDeserializer(TitleFieldResponse.class, new TitleFieldResponseDeserializer())
+      .addDeserializer(TitleFieldResponseTitleInner.class, new TitleFieldResponseDeserializer())
       .addDeserializer(InstanceResponseAllOfMap.class, new InstanceResponseAllOfMapDeserializer())
     );
     PARAMETERS.excludeField(named("id"));

--- a/src/test/java/org/folio/linked/data/test/json/TitleFieldResponseDeserializer.java
+++ b/src/test/java/org/folio/linked/data/test/json/TitleFieldResponseDeserializer.java
@@ -12,21 +12,21 @@ import java.io.IOException;
 import java.util.Map;
 import org.folio.linked.data.domain.dto.ParallelTitleFieldResponse;
 import org.folio.linked.data.domain.dto.PrimaryTitleFieldResponse;
-import org.folio.linked.data.domain.dto.TitleFieldResponse;
+import org.folio.linked.data.domain.dto.TitleFieldResponseTitleInner;
 import org.folio.linked.data.domain.dto.VariantTitleFieldResponse;
 import org.folio.linked.data.util.DtoDeserializer;
 
-public class TitleFieldResponseDeserializer extends JsonDeserializer<TitleFieldResponse> {
-  private static final Map<String, Class<? extends TitleFieldResponse>> IDENDTITY_MAP = Map.of(
+public class TitleFieldResponseDeserializer extends JsonDeserializer<TitleFieldResponseTitleInner> {
+  private static final Map<String, Class<? extends TitleFieldResponseTitleInner>> IDENDTITY_MAP = Map.of(
     TITLE.getUri(), PrimaryTitleFieldResponse.class,
     PARALLEL_TITLE.getUri(), ParallelTitleFieldResponse.class,
     VARIANT_TITLE.getUri(), VariantTitleFieldResponse.class
   );
-  private final DtoDeserializer<TitleFieldResponse> dtoDeserializer =
-    new DtoDeserializer<>(TitleFieldResponse.class, IDENDTITY_MAP, EMPTY_EXCEPTION_BUILDER);
+  private final DtoDeserializer<TitleFieldResponseTitleInner> dtoDeserializer =
+    new DtoDeserializer<>(TitleFieldResponseTitleInner.class, IDENDTITY_MAP, EMPTY_EXCEPTION_BUILDER);
 
   @Override
-  public TitleFieldResponse deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
+  public TitleFieldResponseTitleInner deserialize(JsonParser jp, DeserializationContext dc) throws IOException {
     return dtoDeserializer.deserialize(jp);
   }
 }

--- a/src/test/java/org/folio/linked/data/validation/dto/PrimaryTitleDtoValidatorTest.java
+++ b/src/test/java/org/folio/linked/data/validation/dto/PrimaryTitleDtoValidatorTest.java
@@ -8,7 +8,7 @@ import org.folio.linked.data.domain.dto.ParallelTitle;
 import org.folio.linked.data.domain.dto.ParallelTitleField;
 import org.folio.linked.data.domain.dto.PrimaryTitle;
 import org.folio.linked.data.domain.dto.PrimaryTitleField;
-import org.folio.linked.data.domain.dto.TitleFieldRequest;
+import org.folio.linked.data.domain.dto.TitleFieldRequestTitleInner;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +29,7 @@ class PrimaryTitleDtoValidatorTest {
   @Test
   void shouldReturnFalse_ifGivenTitleFieldRequestListIsEmpty() {
     // given
-    var titleFields = new ArrayList<TitleFieldRequest>();
+    var titleFields = new ArrayList<TitleFieldRequestTitleInner>();
 
     // when
     boolean result = validator.isValid(titleFields, null);
@@ -41,7 +41,7 @@ class PrimaryTitleDtoValidatorTest {
   @Test
   void shouldReturnFalse_ifGivenTitleFieldRequestListContainsNoPrimaryTitle() {
     // given
-    var titleFields = new ArrayList<TitleFieldRequest>();
+    var titleFields = new ArrayList<TitleFieldRequestTitleInner>();
     titleFields.add(new ParallelTitleField().parallelTitle(
       new ParallelTitle().mainTitle(List.of("parallel main title"))
     ));
@@ -56,7 +56,7 @@ class PrimaryTitleDtoValidatorTest {
   @Test
   void shouldReturnFalse_ifGivenTitleFieldRequestListContainsPrimaryTitleWithNoMainTitle() {
     // given
-    var titleFields = new ArrayList<TitleFieldRequest>();
+    var titleFields = new ArrayList<TitleFieldRequestTitleInner>();
     titleFields.add(new ParallelTitleField().parallelTitle(
       new ParallelTitle().mainTitle(List.of("parallel main title"))
     ));
@@ -74,7 +74,7 @@ class PrimaryTitleDtoValidatorTest {
   @Test
   void shouldReturnTrue_ifGivenTitleFieldListContainsPrimaryTitleWithMainTitle() {
     // given
-    var titleFields = new ArrayList<TitleFieldRequest>();
+    var titleFields = new ArrayList<TitleFieldRequestTitleInner>();
     titleFields.add(new ParallelTitleField().parallelTitle(
       new ParallelTitle().mainTitle(List.of("parallel main title"))
     ));


### PR DESCRIPTION
**Problem:**

When `oneOf` is at the top level (as in [TitleFieldRequest.json](https://github.com/folio-org/mod-linked-data/blob/master/src/main/resources/swagger.api/schema/resource/request/title/TitleFieldRequest.json)), then you have to give the full path in `ref` element in line 10, 21 & 32. If relative path is used, maven openapi plugin will fail. This problem do not occur if `allOf` is in the top level as in [this](https://github.com/folio-org/mod-linked-data/blob/master/src/main/resources/swagger.api/schema/resource/request/identifier/IsbnRequest.json) file. So, I believe it is a bug in the plugin.

However, if you give full path, then the [python script](https://github.com/folio-org/folio-tools/blob/master/api-doc/api_doc.py) used by jenkins to generate api-doc will fail with error `Error: Invalid JSON pointer: schema/resource/common/title/PrimaryTitle.json`. See [this](https://github.com/folio-org/mod-linked-data/actions/runs/11974704482/job/33386376071) failed build (build is shown Green even though it actually failed). Expand  "Do api-doc" to see the failure.

**Fix given in this ticket:**
I rearranged the JSON schemas so that "oneOf" element do not appear in the top level. This way, we can give relative paths in "$ref" element. This will make the python script & `mvn clean install` pass. See [this](https://github.com/folio-org/mod-linked-data/actions/runs/11979441248/job/33401626320 ) java doc generation using this branch.
