### PR TITLE
MODLD-650: Include tenant ID, request ID, user ID & module ID in log messages; Optimize logs for event consumption.

### DIFF
--- a/src/main/java/org/folio/linked/data/integration/kafka/listener/SourceRecordDomainEventListener.java
+++ b/src/main/java/org/folio/linked/data/integration/kafka/listener/SourceRecordDomainEventListener.java
@@ -47,7 +47,7 @@ public class SourceRecordDomainEventListener {
   }
 
   private void processRecord(ConsumerRecord<String, SourceRecordDomainEvent> consumerRecord) {
-    log.info("Received event [key {}]", consumerRecord.key());
+    log.debug("Received event [key {}]", consumerRecord.key());
     var event = consumerRecord.value();
     if (notAllRequiredHeaders(consumerRecord.headers())) {
       log.warn("Received SourceRecordDomainEvent [id {}] will be ignored since not all required headers were provided",

--- a/src/main/java/org/folio/linked/data/integration/kafka/listener/handler/InventoryInstanceEventHandler.java
+++ b/src/main/java/org/folio/linked/data/integration/kafka/listener/handler/InventoryInstanceEventHandler.java
@@ -23,10 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Profile("!" + STANDALONE_PROFILE)
 public class InventoryInstanceEventHandler {
 
-  public static final String INSTANCE_REINDEX_NOT_REQUIRED = "Ignoring InventoryInstanceEvent '{}',"
+  private static final String INSTANCE_REINDEX_NOT_REQUIRED = "Ignoring InventoryInstanceEvent '{}',"
     + " reindexing not required.";
-  public static final String SENT_FOR_REINDEXING = "Instance '{}' has some fields updated, sent for reindexing.";
-  public static final String SUPPRESS_FLAGS_CHANGED = "InventoryInstanceEvent:{} - changes in suppress flags: {}.";
+  private static final String SENT_FOR_REINDEXING = "Instance '{}' has some fields updated, sent for reindexing.";
+  private static final String SUPPRESS_FLAGS_CHANGED = "InventoryInstanceEvent:{} - changes in suppress flags: {}.";
+  private static final String UPDATING_SUPPRESS_FLAGS = "Updating suppress flags for instance {}. Staff: {}, "
+    + "discovery: {}";
 
   private final FolioMetadataRepository folioMetadataRepository;
   private final WorkUpdateMessageSender workUpdateMessageSender;
@@ -52,8 +54,10 @@ public class InventoryInstanceEventHandler {
   }
 
   private Resource updateMetadataAndGetResource(FolioMetadata folioMetadata, InventoryInstanceEvent event) {
-    folioMetadata.setStaffSuppress(event.getNew().getStaffSuppress());
-    folioMetadata.setSuppressFromDiscovery(event.getNew().getDiscoverySuppress());
+    var instance = event.getNew();
+    log.info(UPDATING_SUPPRESS_FLAGS, instance.getId(), instance.getStaffSuppress(), instance.getDiscoverySuppress());
+    folioMetadata.setStaffSuppress(instance.getStaffSuppress());
+    folioMetadata.setSuppressFromDiscovery(instance.getDiscoverySuppress());
     return folioMetadataRepository.save(folioMetadata).getResource();
   }
 

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -1,3 +1,6 @@
+name = PropertiesConfig
+packages = org.folio.spring.logging
+
 appenders = console
 
 appender.console.type = Console
@@ -6,43 +9,33 @@ appender.console.layout.type = JSONLayout
 appender.console.layout.compact = true
 appender.console.layout.eventEol = true
 appender.console.layout.stacktraceAsString = true
+appender.console.layout.includeTimeMillis = true
 
-packages = org.folio.okapi.common.logging
 appender.console.layout.requestId.type = KeyValuePair
 appender.console.layout.requestId.key = requestId
-appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
+appender.console.layout.requestId.value = $${folio:requestid:-}
 
 appender.console.layout.tenantId.type = KeyValuePair
 appender.console.layout.tenantId.key = tenantId
-appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
+appender.console.layout.tenantId.value = $${folio:tenantid:-}
 
 appender.console.layout.userId.type = KeyValuePair
 appender.console.layout.userId.key = userId
-appender.console.layout.userId.value = $${FolioLoggingContext:userid}
+appender.console.layout.userId.value = $${folio:userid:-}
 
 appender.console.layout.moduleId.type = KeyValuePair
 appender.console.layout.moduleId.key = moduleId
-appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
-
-logger.folio_services.name = org.folio.services
-logger.folio_services.level = debug
-logger.folio_services.additivity = false
-logger.folio_services.appenderRef.stdout.ref = STDOUT
-
-logger.folio_consumers.name = org.folio.consumers
-logger.folio_consumers.level = debug
-logger.folio_consumers.additivity = false
-logger.folio_consumers.appenderRef.stdout.ref = STDOUT
-
-#disable ProducerConfig/ConsumerConfig messages in log
-logger.kafka.name = org.apache.kafka
-logger.kafka.level = ERROR
-logger.kafka.additivity = false
-logger.kafka.appenderRef.stdout.ref = STDOUT
+appender.console.layout.moduleId.value = $${folio:moduleid:-}
 
 rootLogger.level = info
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+#disable ProducerConfig, ConsumerConfig, folio_persist & CQL messages in log
+logger.kafka.name = org.apache.kafka
+logger.kafka.level = ERROR
+logger.kafka.additivity = false
+logger.kafka.appenderRef.stdout.ref = STDOUT
 
 logger.folio_persist.name = org.folio.rest.persist
 logger.folio_persist.level = ERROR

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,31 +1,22 @@
 appenders = console
 
-packages = org.folio.okapi.common.logging
+name = PropertiesConfig
+packages = org.folio.spring.logging
 
 appender.console.type = Console
 appender.console.name = STDOUT
 
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} %m%n
-
-logger.folio_services.name = org.folio.services
-logger.folio_services.level = debug
-logger.folio_services.additivity = false
-logger.folio_services.appenderRef.stdout.ref = STDOUT
-
-logger.folio_consumers.name = org.folio.consumers
-logger.folio_consumers.level = debug
-logger.folio_consumers.additivity = false
-logger.folio_consumers.appenderRef.stdout.ref = STDOUT
-
-#disable ProducerConfig/ConsumerConfig messages in log
-logger.kafka.name = org.apache.kafka
-logger.kafka.level = ERROR
-logger.kafka.appenderRef.stdout.ref = STDOUT
+appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestid:-}] [$${folio:tenantid:-}] [$${folio:userid:-}] [$${folio:moduleid:-}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT
+
+#disable ProducerConfig, ConsumerConfig, folio_persist & CQL messages in log
+logger.kafka.name = org.apache.kafka
+logger.kafka.level = ERROR
+logger.kafka.appenderRef.stdout.ref = STDOUT
 
 logger.folio_persist.name = org.folio.rest.persist
 logger.folio_persist.level = ERROR


### PR DESCRIPTION
**Current Logs:** (No tenant ID, user ID etc in log message)
<img width="1534" alt="Screenshot 2025-01-30 at 1 05 18 PM" src="https://github.com/user-attachments/assets/409738e1-1987-47f2-963a-251d9fb12957" />


**After the change:**

Normal Logs:
<img width="1324" alt="Screenshot 2025-01-30 at 12 54 45 PM" src="https://github.com/user-attachments/assets/6f06edbc-172b-44e5-a385-6539631f8e38" />


JSON logs:
<img width="1611" alt="Screenshot 2025-01-30 at 12 49 47 PM" src="https://github.com/user-attachments/assets/982ebb72-1996-4002-a384-ca60ebd7e36a" />
