### PR TITLE
MODLD-695: "targetAudience", "geographicCoverage" links contain https instead of http

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.0.2 (IN PROGRESS)
--
+- "targetAudience", "geographicCoverage" links contain https instead of http [MODLD-695](https://folio-org.atlassian.net/browse/MODLD-695)
 
 ## 1.0.1
 - Initial release

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
@@ -1506,11 +1506,11 @@ abstract class ResourceControllerITBase extends AbstractResourceControllerIT {
     var unitedStates = saveResource(7109832602847218134L, "United States", PLACE,
       "{\"http://bibfra.me/vocab/lite/name\": [\"United States\"], "
         + "\"http://bibfra.me/vocab/marc/geographicAreaCode\": [\"n-us\"], "
-        + "\"http://bibfra.me/vocab/marc/geographicCoverage\": [\"https://id.loc.gov/vocabulary/geographicAreas/n-us\"]}");
+        + "\"http://bibfra.me/vocab/marc/geographicCoverage\": [\"http://id.loc.gov/vocabulary/geographicAreas/n-us\"]}");
     var europe = saveResource(-4654600487710655316L, "Europe", PLACE,
       "{\"http://bibfra.me/vocab/lite/name\": [\"Europe\"], "
         + "\"http://bibfra.me/vocab/marc/geographicAreaCode\": [\"e\"], "
-        + "\"http://bibfra.me/vocab/marc/geographicCoverage\": [\"https://id.loc.gov/vocabulary/geographicAreas/e\"]}");
+        + "\"http://bibfra.me/vocab/marc/geographicCoverage\": [\"http://id.loc.gov/vocabulary/geographicAreas/e\"]}");
     var genre1 = saveResource(-9064822434663187463L, "genre 1", FORM,
       "{\"http://bibfra.me/vocab/lite/name\": [\"genre 1\"]}", "8138e88f-4278-45ba-838c-816b80544f82");
     var genre2 = saveResource(-4816872480602594231L, "genre 2", FORM,

--- a/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
@@ -479,7 +479,7 @@ public class MonographTestUtil {
       Map.of(
         NAME, List.of("United States"),
         GEOGRAPHIC_AREA_CODE, List.of("n-us"),
-        GEOGRAPHIC_COVERAGE, List.of("https://id.loc.gov/vocabulary/geographicAreas/n-us")
+        GEOGRAPHIC_COVERAGE, List.of("http://id.loc.gov/vocabulary/geographicAreas/n-us")
       ),
       Set.of(PLACE),
       emptyMap()
@@ -490,7 +490,7 @@ public class MonographTestUtil {
       Map.of(
         NAME, List.of("Europe"),
         GEOGRAPHIC_AREA_CODE, List.of("e"),
-        GEOGRAPHIC_COVERAGE, List.of("https://id.loc.gov/vocabulary/geographicAreas/e")
+        GEOGRAPHIC_COVERAGE, List.of("http://id.loc.gov/vocabulary/geographicAreas/e")
       ),
       Set.of(PLACE),
       emptyMap()


### PR DESCRIPTION
fingerprint: https://github.com/folio-org/lib-linked-data-fingerprint/pull/40
marc4ld: https://github.com/folio-org/lib-linked-data-marc4ld/pull/80