### PR TITLE
MODLD-726: Update API to support 340 (Book Format)

### DIFF
--- a/src/main/java/org/folio/linked/data/mapper/dto/common/CoreMapperImpl.java
+++ b/src/main/java/org/folio/linked/data/mapper/dto/common/CoreMapperImpl.java
@@ -3,21 +3,17 @@ package org.folio.linked.data.mapper.dto.common;
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
-import static org.folio.ld.dictionary.PropertyDictionary.LANGUAGE;
-import static org.folio.ld.dictionary.PropertyDictionary.TARGET_AUDIENCE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
 import org.folio.ld.dictionary.model.Predicate;
-import org.folio.linked.data.domain.dto.WorkResponse;
 import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
@@ -90,12 +86,6 @@ public class CoreMapperImpl implements CoreMapper {
   private <T> T readDoc(JsonNode node, Class<T> dtoClass) {
     try {
       if (nonNull(node)) {
-        if (dtoClass == WorkResponse.class) {
-          // Temp fix - below properties loaded through the Python ETL have values in text format
-          // causing the deserialization to fail. Here remove such properties from node
-          ((ObjectNode) node).remove(TARGET_AUDIENCE.getValue());
-          ((ObjectNode) node).remove(LANGUAGE.getValue());
-        }
         return jsonMapper.treeToValue(node, dtoClass);
       } else {
         return jsonMapper.treeToValue(jsonMapper.createObjectNode(), dtoClass);
@@ -105,5 +95,4 @@ public class CoreMapperImpl implements CoreMapper {
       throw exceptionBuilder.mappingException(dtoClass.getSimpleName(), String.valueOf(node));
     }
   }
-
 }

--- a/src/main/java/org/folio/linked/data/mapper/dto/monograph/instance/sub/BookFormatMapperUnit.java
+++ b/src/main/java/org/folio/linked/data/mapper/dto/monograph/instance/sub/BookFormatMapperUnit.java
@@ -1,0 +1,48 @@
+package org.folio.linked.data.mapper.dto.monograph.instance.sub;
+
+import static org.folio.ld.dictionary.PredicateDictionary.BOOK_FORMAT;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.CATEGORY;
+
+import org.folio.linked.data.domain.dto.Category;
+import org.folio.linked.data.domain.dto.CategoryResponse;
+import org.folio.linked.data.domain.dto.InstanceResponse;
+import org.folio.linked.data.mapper.dto.common.CoreMapper;
+import org.folio.linked.data.mapper.dto.common.MapperUnit;
+import org.folio.linked.data.mapper.dto.monograph.common.CategoryMapperUnit;
+import org.folio.linked.data.service.resource.hash.HashService;
+import org.springframework.stereotype.Component;
+
+@Component
+@MapperUnit(type = CATEGORY, predicate = BOOK_FORMAT, requestDto = Category.class)
+public class BookFormatMapperUnit  extends CategoryMapperUnit {
+
+  private static final String CATEGORY_SET_LABEL = "Book Format";
+  private static final String CATEGORY_SET_LINK = "http://id.loc.gov/vocabulary/bookformat";
+  private static final String BOOK_FORMAT_TYPE_LINK_PREFIX = "http://id.loc.gov/vocabulary/bookformat/";
+
+  public BookFormatMapperUnit(HashService hashService, CoreMapper coreMapper) {
+    super(hashService, coreMapper);
+  }
+
+  @Override
+  protected void addToParent(CategoryResponse category, Object parentDto) {
+    if (parentDto instanceof InstanceResponse instance) {
+      instance.addBookFormatItem(category);
+    }
+  }
+
+  @Override
+  protected String getCategorySetLabel() {
+    return CATEGORY_SET_LABEL;
+  }
+
+  @Override
+  protected String getCategorySetLink() {
+    return CATEGORY_SET_LINK;
+  }
+
+  @Override
+  public String getLinkPrefix() {
+    return BOOK_FORMAT_TYPE_LINK_PREFIX;
+  }
+}

--- a/src/main/resources/swagger.api/schema/resource/request/InstanceRequest.json
+++ b/src/main/resources/swagger.api/schema/resource/request/InstanceRequest.json
@@ -223,6 +223,14 @@
           },
           "x-json-property": "http://bibfra.me/vocab/marc/accompanyingMaterial"
         },
+        "bookFormat": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "../common/Category.json"
+          },
+          "x-json-property": "http://bibfra.me/vocab/marc/bookFormat"
+        },
         "_notes": {
           "type": "array",
           "items": {

--- a/src/main/resources/swagger.api/schema/resource/response/CategoryResponse.json
+++ b/src/main/resources/swagger.api/schema/resource/response/CategoryResponse.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Category object",
+  "x-from-string-field": "term",
   "allOf": [
     {
       "$ref": "../common/IdField.json"

--- a/src/main/resources/swagger.api/schema/resource/response/InstanceResponse.json
+++ b/src/main/resources/swagger.api/schema/resource/response/InstanceResponse.json
@@ -225,6 +225,14 @@
           },
           "x-json-property": "http://bibfra.me/vocab/marc/accompanyingMaterial"
         },
+        "bookFormat": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "CategoryResponse.json"
+          },
+          "x-json-property": "http://bibfra.me/vocab/marc/bookFormat"
+        },
         "_notes": {
           "type": "array",
           "items": {

--- a/src/main/resources/swagger.api/templates/pojo.mustache
+++ b/src/main/resources/swagger.api/templates/pojo.mustache
@@ -111,6 +111,17 @@ public class {{classname}}{{#parent}} extends {{{parent}}}{{/parent}}{{^parent}}
   }
   {{/hasRequired}}
   {{/generatedConstructorWithRequiredArgs}}
+
+  {{#vendorExtensions.x-from-string-field}}
+  {{^hasRequired}}
+  public {{classname}}() {}
+  {{/hasRequired}}
+
+  public {{classname}}(String value) {
+    this.{{.}} = List.of(value);
+  }
+  {{/vendorExtensions.x-from-string-field}}
+
   {{#vars}}
 
   {{! begin feature: fluent setter methods }}

--- a/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
@@ -1,0 +1,138 @@
+package org.folio.linked.data.e2e.mappings.bookformat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.linked.data.test.TestUtil.STANDALONE_TEST_PROFILE;
+import static org.folio.linked.data.test.TestUtil.defaultHeaders;
+import static org.folio.linked.data.util.Constants.STANDALONE_PROFILE;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.folio.linked.data.e2e.base.IntegrationTest;
+import org.folio.linked.data.model.entity.Resource;
+import org.folio.linked.data.model.entity.ResourceEdge;
+import org.folio.linked.data.test.resource.ResourceTestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@IntegrationTest
+@ActiveProfiles({STANDALONE_PROFILE, STANDALONE_TEST_PROFILE})
+class BookFormatIT {
+  static final String RESOURCE_URL = "/linked-data/resource";
+
+  @Autowired
+  protected MockMvc mockMvc;
+  @Autowired
+  protected Environment env;
+  @Autowired
+  protected ResourceTestService resourceService;
+
+  @Test
+  void postResource_shouldCreateBookFormat() throws Exception {
+    // given
+    var requestPayload = postInstanceApiRequest();
+    var expectedInstanceId = -7766153465587539469L;
+
+    var postRequest = post(RESOURCE_URL)
+      .contentType(APPLICATION_JSON)
+      .headers(defaultHeaders(env))
+      .content(requestPayload);
+
+    // when
+    var postResponse = mockMvc.perform(postRequest);
+
+    // then
+    validateApiResponse(postResponse);
+
+    validateGraph(expectedInstanceId);
+
+    var getRequest = get(RESOURCE_URL + "/" + expectedInstanceId)
+      .contentType(APPLICATION_JSON)
+      .headers(defaultHeaders(env));
+    var getResponse = mockMvc.perform(getRequest);
+    validateApiResponse(getResponse);
+  }
+
+  private String postInstanceApiRequest() {
+    return """
+      {
+         "resource":{
+            "http://bibfra.me/vocab/lite/Instance":{
+               "http://bibfra.me/vocab/marc/title":[
+                  {
+                     "http://bibfra.me/vocab/marc/Title":{
+                        "http://bibfra.me/vocab/marc/mainTitle":[ "title" ]
+                     }
+                  }
+               ],
+               "http://bibfra.me/vocab/marc/bookFormat":[
+                  {
+                     "http://bibfra.me/vocab/marc/term":[ "128mo" ],
+                     "http://bibfra.me/vocab/lite/link": ["http://id.loc.gov/vocabulary/bookformat/128mo"]
+                  }, {
+                     "http://bibfra.me/vocab/marc/term":[ "non-standard-format" ]
+                  }
+               ]
+            }
+         }
+      }""";
+  }
+
+  private void validateApiResponse(ResultActions apiResponse) throws Exception {
+    var bookFormatPath = "$.resource['http://bibfra.me/vocab/lite/Instance']['http://bibfra.me/vocab/marc/bookFormat']";
+    apiResponse
+      .andExpect(status().isOk())
+      .andExpect(
+        jsonPath(bookFormatPath + "[0]['http://bibfra.me/vocab/marc/term'][0]")
+          .value("non-standard-format"))
+      .andExpect(jsonPath(bookFormatPath + "[1]['http://bibfra.me/vocab/marc/term'][0]")
+        .value("128mo"))
+      .andExpect(
+        jsonPath(bookFormatPath + "[1]['http://bibfra.me/vocab/marc/code'][0]")
+          .value("128mo"))
+      .andExpect(
+        jsonPath(bookFormatPath + "[1]['http://bibfra.me/vocab/lite/link'][0]")
+          .value("http://id.loc.gov/vocabulary/bookformat/128mo"));
+  }
+
+  private void validateGraph(long instanceId) {
+    var expectedBookFormatId = 1710735011707999802L;
+    var expectedCategorySetId = -5037749211942465056L;
+    var instance = resourceService.getResourceById(instanceId + "", 3);
+    assertThat(instance.getId()).isEqualTo(instanceId);
+    assertThat(getProperty(instance, "http://bibfra.me/vocab/marc/bookFormat"))
+      .isEqualTo("non-standard-format");
+
+    var bookFormat = getTarget(instance, "http://bibfra.me/vocab/marc/bookFormat");
+    assertThat(bookFormat.getId()).isEqualTo(expectedBookFormatId);
+    assertThat(getProperty(bookFormat, "http://bibfra.me/vocab/marc/term")).isEqualTo("128mo");
+    assertThat(getProperty(bookFormat, "http://bibfra.me/vocab/marc/code")).isEqualTo("128mo");
+    assertThat(getProperty(bookFormat, "http://bibfra.me/vocab/lite/link"))
+      .isEqualTo("http://id.loc.gov/vocabulary/bookformat/128mo");
+    assertThat(bookFormat.getLabel()).isEqualTo("128mo");
+
+    var categorySet = getTarget(bookFormat, "http://bibfra.me/vocab/lite/isDefinedBy");
+    assertThat(categorySet.getId()).isEqualTo(expectedCategorySetId);
+    assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/label")).isEqualTo("Book Format");
+    assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/link"))
+      .isEqualTo("http://id.loc.gov/vocabulary/bookformat");
+    assertThat(categorySet.getLabel()).isEqualTo("Book Format");
+  }
+
+  private String getProperty(Resource resource, String property) {
+    return resource.getDoc().get(property).get(0).asText();
+  }
+
+  private Resource getTarget(Resource resource, String predicate) {
+    return resource.getOutgoingEdges().stream()
+      .filter(edge -> edge.getPredicate().getUri().equals(predicate))
+      .map(ResourceEdge::getTarget)
+      .findFirst().orElseThrow();
+  }
+}


### PR DESCRIPTION
### Summary
Enhanced the Instance API request and response DTOs by adding support for the `bookFormat` object property.

### POST Request Handling

- If the bookFormat object includes a `link` property, it is treated as a valid book format. In this case:

   - `Category` & `CategorySet` nodes is created.
   - An outgoing relationship is established from the `Instance` node to the `Category` node.
   - An outgoing relationship is established from the `Category` node to the `CategorySet` node.

- If the bookFormat object lacks a link property, it is considered a non-standard book format:

  - The value is stored as a simple string property directly on the `Instance` node.

### Issue Encountered
For instances with non-standard book formats, the Instance node contains a string property for bookFormat (e.g.,
`"http://bibfra.me/vocab/marc/bookFormat": ["some text"]`). However, the API response model expects `http://bibfra.me/vocab/marc/bookFormat` to be an object of type `CategoryResponse`. This causes Jackson to fail when attempting to deserialize a string into a `CategoryResponse` object.

### Solution
To address this, a "fromString" constructor was added to the generated `CategoryResponse` class.
A corresponding change was made in the `pojo.mustache` template to support this behavior during code generation.

