### PR TITLE
MODLD-740: Define server response to file import

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2.0.0 (IN PROGRESS)
 - Created new API GET /profile/{id} [MODLD-713](https://folio-org.atlassian.net/browse/MODLD-713)
+- Created new API POST /import/file [MODLD-729](https://folio-org.atlassian.net/browse/MODLD-729), [MODLD-740](https://folio-org.atlassian.net/browse/MODLD-740)
 
 ### Breaking changes
 - Updated API to support Extent [MODLD-390](https://folio-org.atlassian.net/browse/MODLD-390)

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <folio-kafka-wrapper.version>3.3.1</folio-kafka-wrapper.version>
     <apache-commons-io.version>2.19.0</apache-commons-io.version>
     <apache-commons-collections.version>4.5.0</apache-commons-collections.version>
+    <apache-commons-csv.version>1.14.0</apache-commons-csv.version>
     <mapstruct.version>1.6.3</mapstruct.version>
     <lombok.version>1.18.38</lombok.version>
     <lombok.mapstruct-binding.version>0.2.0</lombok.mapstruct-binding.version>
@@ -177,6 +178,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
       <version>${apache-commons-collections.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>${apache-commons-csv.version}</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/linked/data/controller/ImportController.java
+++ b/src/main/java/org/folio/linked/data/controller/ImportController.java
@@ -1,7 +1,7 @@
 package org.folio.linked.data.controller;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.folio.linked.data.domain.dto.ImportFileResponseDto;
 import org.folio.linked.data.rest.resource.ImportApi;
 import org.folio.linked.data.service.rdf.RdfImportService;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +14,7 @@ public class ImportController implements ImportApi {
   private final RdfImportService rdfImportService;
 
   @Override
-  public ResponseEntity<List<Long>> importFile(MultipartFile multipartFile) {
+  public ResponseEntity<ImportFileResponseDto> importFile(MultipartFile multipartFile) {
     return ResponseEntity.ok(rdfImportService.importFile(multipartFile));
   }
 }

--- a/src/main/java/org/folio/linked/data/service/rdf/RdfImportService.java
+++ b/src/main/java/org/folio/linked/data/service/rdf/RdfImportService.java
@@ -1,10 +1,10 @@
 package org.folio.linked.data.service.rdf;
 
-import java.util.List;
+import org.folio.linked.data.domain.dto.ImportFileResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface RdfImportService {
 
-  List<Long> importFile(MultipartFile multipartFile);
+  ImportFileResponseDto importFile(MultipartFile multipartFile);
 
 }

--- a/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
@@ -1,7 +1,6 @@
 package org.folio.linked.data.service.rdf;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -42,10 +41,9 @@ public class RdfImportServiceImpl implements RdfImportService {
   }
 
   private ImportFileResponseDto save(Set<org.folio.ld.dictionary.model.Resource> resources) {
-    ImportFileResponseDto response;
-    String reportCsv = "";
-    ImportUtils.ImportReport report = new ImportUtils.ImportReport();
-    List<Long> ids = resources.stream()
+    var reportCsv = "";
+    var report = new ImportUtils.ImportReport();
+    var ids = resources.stream()
       .map(resourceModelMapper::toEntity)
       .filter(r -> {
         boolean exists = resourceRepo.existsById(r.getId());
@@ -75,9 +73,8 @@ public class RdfImportServiceImpl implements RdfImportService {
     try {
       reportCsv = report.toCsv();
     } catch (IOException e) {
-      log.warn("I/O error while generating CSV report, returning empty report: {}", e);
+      log.warn("I/O error while generating CSV report, returning empty report", e);
     }
-    response = new ImportFileResponseDto(ids, reportCsv);
-    return response;
+    return new ImportFileResponseDto(ids, reportCsv);
   }
 }

--- a/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.linked.data.domain.dto.ImportFileResponseDto;
 import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.folio.linked.data.mapper.ResourceModelMapper;
 import org.folio.linked.data.model.entity.event.ResourceCreatedEvent;
 import org.folio.linked.data.repo.ResourceRepository;
 import org.folio.linked.data.service.resource.graph.ResourceGraphService;
 import org.folio.linked.data.service.resource.meta.MetadataService;
+import org.folio.linked.data.util.ImportUtils;
 import org.folio.rdf4ld.service.Rdf4LdService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
@@ -30,22 +32,30 @@ public class RdfImportServiceImpl implements RdfImportService {
   private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
-  public List<Long> importFile(MultipartFile multipartFile) {
+  public ImportFileResponseDto importFile(MultipartFile multipartFile) {
     try (var is = multipartFile.getInputStream()) {
-      var resources = rdf4LdService.mapToLdInstance(is, multipartFile.getContentType());
+      var resources = rdf4LdService.mapToLdInstance(is, ImportUtils.toRdfMediaType(multipartFile.getContentType()));
       return save(resources);
     } catch (IOException e) {
       throw exceptionBuilder.badRequestException("Rdf import incoming file reading error", e.getMessage());
     }
   }
 
-  private List<Long> save(Set<org.folio.ld.dictionary.model.Resource> resources) {
-    return resources.stream()
+  private ImportFileResponseDto save(Set<org.folio.ld.dictionary.model.Resource> resources) {
+    ImportFileResponseDto response;
+    String reportCsv = "";
+    ImportUtils.ImportReport report = new ImportUtils.ImportReport();
+    List<Long> ids = resources.stream()
       .map(resourceModelMapper::toEntity)
       .filter(r -> {
         boolean exists = resourceRepo.existsById(r.getId());
         if (exists) {
-          log.warn("Instance with id {} was ignored during RDF import because it exists already", r.getId());
+          report.addImport(
+            new ImportUtils.ImportReport.ImportedResource(
+              r.getId(),
+              r.getLabel(),
+              ImportUtils.ImportReport.Status.FAILURE,
+              "Already exists in graph"));
         }
         return !exists;
       })
@@ -53,8 +63,21 @@ public class RdfImportServiceImpl implements RdfImportService {
         metadataService.ensure(resource);
         var saved = resourceGraphService.saveMergingGraph(resource);
         applicationEventPublisher.publishEvent(new ResourceCreatedEvent(saved));
+        report.addImport(
+          new ImportUtils.ImportReport.ImportedResource(
+            saved.getId(),
+            saved.getLabel(),
+            ImportUtils.ImportReport.Status.SUCCESS,
+            ""));
         return resource.getId();
       })
       .toList();
+    try {
+      reportCsv = report.toCsv();
+    } catch (IOException e) {
+      log.warn("I/O error while generating CSV report, returning empty report: {}", e);
+    }
+    response = new ImportFileResponseDto(ids, reportCsv);
+    return response;
   }
 }

--- a/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
@@ -69,7 +69,7 @@ public class RdfImportServiceImpl implements RdfImportService {
             saved.getLabel(),
             ImportUtils.Status.SUCCESS,
             ""));
-        return resource.getId();
+        return resource.getId().toString();
       })
       .toList();
     try {

--- a/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/rdf/RdfImportServiceImpl.java
@@ -51,10 +51,10 @@ public class RdfImportServiceImpl implements RdfImportService {
         boolean exists = resourceRepo.existsById(r.getId());
         if (exists) {
           report.addImport(
-            new ImportUtils.ImportReport.ImportedResource(
+            new ImportUtils.ImportedResource(
               r.getId(),
               r.getLabel(),
-              ImportUtils.ImportReport.Status.FAILURE,
+              ImportUtils.Status.FAILURE,
               "Already exists in graph"));
         }
         return !exists;
@@ -64,10 +64,10 @@ public class RdfImportServiceImpl implements RdfImportService {
         var saved = resourceGraphService.saveMergingGraph(resource);
         applicationEventPublisher.publishEvent(new ResourceCreatedEvent(saved));
         report.addImport(
-          new ImportUtils.ImportReport.ImportedResource(
+          new ImportUtils.ImportedResource(
             saved.getId(),
             saved.getLabel(),
-            ImportUtils.ImportReport.Status.SUCCESS,
+            ImportUtils.Status.SUCCESS,
             ""));
         return resource.getId();
       })

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -52,25 +52,25 @@ public class ImportUtils {
     return finalType;
   }
 
+  @RequiredArgsConstructor
+  public enum Status {
+    SUCCESS("Success"),
+    FAILURE("Failure");
+
+    private final String value;
+  }
+
+  @Data
+  @AllArgsConstructor
+  public static class ImportedResource {
+    private Long id;
+    private String label;
+    private Status status;
+    private String failureReason;
+  }
+
   @Data
   public static class ImportReport {
-    @RequiredArgsConstructor
-    public enum Status {
-      SUCCESS("Success"),
-      FAILURE("Failure");
-
-      private final String value;
-    }
-
-    @Data
-    @AllArgsConstructor
-    public static class ImportedResource {
-      private Long id;
-      private String label;
-      private Status status;
-      private String failureReason;
-    }
-
     private List<ImportedResource> imports = new ArrayList<>();
 
     public boolean addImport(ImportedResource resource) {
@@ -79,7 +79,7 @@ public class ImportUtils {
 
     public String toCsv() throws IOException {
       StringWriter sw = new StringWriter();
-      CSVFormat format = CSVFormat.DEFAULT.builder()
+      CSVFormat format = CSVFormat.EXCEL.builder()
         .setHeader(ReportHeader.class)
         .get();
       try (final CSVPrinter printer = new CSVPrinter(sw, format)) {

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -1,0 +1,92 @@
+package org.folio.linked.data.util;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.UtilityClass;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+
+@Log4j2
+@UtilityClass
+public class ImportUtils {
+  public static final String APPLICATION_LD_JSON_VALUE = "application/ld+json";
+  public static final String TEXT_TURTLE_VALUE = "text/turtle";
+
+  private enum ReportHeader {
+    URI,
+    LABEL,
+    STATUS,
+    FAILURE_REASON;
+  }
+
+  /**
+   * Content type is guessed by the browser File API implementation / the
+   * underlying OS and probably doesn't correspond to MIME types the rdf4j
+   * library understands. Map common generic MIME types the browser might 
+   * guess to the appropriate rdf4j equivalent. rdf4j accepts application/xml
+   * already, no map required.
+   * @see https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/rio/RDFFormat.html
+   */
+  public static String toRdfMediaType(String contentType) {
+    String finalType;
+    switch (contentType) {
+      case APPLICATION_JSON_VALUE:
+        finalType = APPLICATION_LD_JSON_VALUE;
+        break;
+      case TEXT_PLAIN_VALUE:
+        finalType = TEXT_TURTLE_VALUE; // Could also be text/n3, assuming ttl is more prevalent
+        break;
+      default:
+        finalType = contentType;
+        break;
+    }
+    return finalType;
+  }
+
+  @Data
+  public static class ImportReport {
+    @RequiredArgsConstructor
+    public enum Status {
+      SUCCESS("Success"),
+      FAILURE("Failure");
+
+      private final String value;
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class ImportedResource {
+      private Long id;
+      private String label;
+      private Status status;
+      private String failureReason;
+    }
+
+    private List<ImportedResource> imports;
+
+    public boolean addImport(ImportedResource resource) {
+      return this.imports.add(resource);
+    }
+
+    public String toCsv() throws IOException {
+      StringWriter sw = new StringWriter();
+      CSVFormat format = CSVFormat.DEFAULT.builder()
+        .setHeader(ReportHeader.class)
+        .get();
+      try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
+        for (ImportedResource resource : imports) {
+          printer.printRecord(resource.getId(), resource.getLabel(), resource.getStatus().value, resource.getFailureReason());
+        }
+      }
+      return sw.toString();
+    }
+  }
+}

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -5,6 +5,7 @@ import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -36,17 +37,17 @@ public class ImportUtils {
    * @see https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/rio/RDFFormat.html
    */
   public static String toRdfMediaType(String contentType) {
-    String finalType;
-    switch (contentType) {
-      case APPLICATION_JSON_VALUE:
-        finalType = APPLICATION_LD_JSON_VALUE;
-        break;
-      case TEXT_PLAIN_VALUE:
-        finalType = TEXT_TURTLE_VALUE; // Could also be text/n3, assuming ttl is more prevalent
-        break;
-      default:
-        finalType = contentType;
-        break;
+    String finalType = contentType;
+    if (contentType != null) {
+      switch (contentType) {
+        case APPLICATION_JSON_VALUE:
+          finalType = APPLICATION_LD_JSON_VALUE;
+          break;
+        case TEXT_PLAIN_VALUE:
+          finalType = TEXT_TURTLE_VALUE; // Could also be text/n3, assuming ttl is more prevalent
+          break;
+        default: // nothing to change if no match
+      }
     }
     return finalType;
   }
@@ -70,7 +71,7 @@ public class ImportUtils {
       private String failureReason;
     }
 
-    private List<ImportedResource> imports;
+    private List<ImportedResource> imports = new ArrayList<>();
 
     public boolean addImport(ImportedResource resource) {
       return this.imports.add(resource);
@@ -83,7 +84,11 @@ public class ImportUtils {
         .get();
       try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
         for (ImportedResource resource : imports) {
-          printer.printRecord(resource.getId(), resource.getLabel(), resource.getStatus().value, resource.getFailureReason());
+          printer.printRecord(
+            resource.getId(),
+            resource.getLabel(),
+            resource.getStatus().value,
+            resource.getFailureReason());
         }
       }
       return sw.toString();

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -34,7 +34,8 @@ public class ImportUtils {
    * library understands. Map common generic MIME types the browser might 
    * guess to the appropriate rdf4j equivalent. rdf4j accepts application/xml
    * already, no map required.
-   * @see https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/rio/RDFFormat.html
+   *
+   * @see <a href="https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/rio/RDFFormat.html">rdf4j documentation</a>
    */
   public static String toRdfMediaType(String contentType) {
     String finalType = contentType;
@@ -82,7 +83,7 @@ public class ImportUtils {
       CSVFormat format = CSVFormat.EXCEL.builder()
         .setHeader(ReportHeader.class)
         .get();
-      try (final CSVPrinter printer = new CSVPrinter(sw, format)) {
+      try (CSVPrinter printer = new CSVPrinter(sw, format)) {
         for (ImportedResource resource : imports) {
           printer.printRecord(
             resource.getId(),

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -38,19 +38,14 @@ public class ImportUtils {
    * @see <a href="https://rdf4j.org/javadoc/latest/org/eclipse/rdf4j/rio/RDFFormat.html">rdf4j documentation</a>
    */
   public static String toRdfMediaType(String contentType) {
-    String finalType = contentType;
-    if (contentType != null) {
-      switch (contentType) {
-        case APPLICATION_JSON_VALUE:
-          finalType = APPLICATION_LD_JSON_VALUE;
-          break;
-        case TEXT_PLAIN_VALUE:
-          finalType = TEXT_TURTLE_VALUE; // Could also be text/n3, assuming ttl is more prevalent
-          break;
-        default: // nothing to change if no match
-      }
+    if (contentType == null) {
+      return null;
     }
-    return finalType;
+    return switch (contentType) {
+      case APPLICATION_JSON_VALUE -> APPLICATION_LD_JSON_VALUE;
+      case TEXT_PLAIN_VALUE -> TEXT_TURTLE_VALUE; // Could also be text/n3, assuming ttl is more prevalent
+      default -> contentType;
+    };
   }
 
   @RequiredArgsConstructor

--- a/src/main/java/org/folio/linked/data/util/ImportUtils.java
+++ b/src/main/java/org/folio/linked/data/util/ImportUtils.java
@@ -22,7 +22,7 @@ public class ImportUtils {
   public static final String TEXT_TURTLE_VALUE = "text/turtle";
 
   private enum ReportHeader {
-    URI,
+    ID,
     LABEL,
     STATUS,
     FAILURE_REASON;

--- a/src/main/resources/swagger.api/mod-linked-data.yaml
+++ b/src/main/resources/swagger.api/mod-linked-data.yaml
@@ -311,14 +311,11 @@ paths:
                   format: binary
       responses:
         '200':
-          description: Placeholder
+          description: Returns a list of resource IDs and an import activity log
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: integer
-                  format: int64
+                $ref: schema/importFileResponseDto.json
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':

--- a/src/main/resources/swagger.api/schema/importFileResponseDto.json
+++ b/src/main/resources/swagger.api/schema/importFileResponseDto.json
@@ -7,8 +7,7 @@
       "type": "array",
       "description": "A list of resource identifiers successfully imported",
       "items": {
-        "type": "integer",
-        "format": "int64"
+        "type": "string"
       }
     },
     "log": {

--- a/src/main/resources/swagger.api/schema/importFileResponseDto.json
+++ b/src/main/resources/swagger.api/schema/importFileResponseDto.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Responds to a file import with a list of imported resources and an activity log",
+  "type": "object",
+  "properties": {
+    "resources": {
+      "type": "array",
+      "description": "A list of resource identifiers successfully imported",
+      "items": {
+        "type": "integer",
+        "format": "int64"
+      }
+    },
+    "log": {
+      "type": "string",
+      "description": "An activity log generated during import"
+    }
+  },
+  "required": [
+    "resources",
+    "log"
+  ]
+}

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -2,7 +2,7 @@ package org.folio.linked.data.e2e.rdf;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -44,7 +44,7 @@ class RdfImportIT {
     resultActions
       .andExpect(status().isOk())
       .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
-      .andExpect(jsonPath("log", contains(Long.toString(expectedId))));
+      .andExpect(jsonPath("log", containsString(Long.toString(expectedId))));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
   }
 

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -57,7 +57,7 @@ class RdfImportIT {
     // then
     resultActions
       .andExpect(status().isOk())
-      .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
+      .andExpect(jsonPath("resources[0]", equalTo(Long.toString(expectedId))))
       .andExpect(jsonPath("log", containsString(Long.toString(expectedId))));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
     verify(eventListener).afterCreate(any());
@@ -84,7 +84,7 @@ class RdfImportIT {
     // then
     resultActions
       .andExpect(status().isOk())
-      .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
+      .andExpect(jsonPath("resources[0]", equalTo(Long.toString(expectedId))))
       .andExpect(jsonPath("log", containsString(Long.toString(expectedId))));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
     assertThat(resourceRepo.existsById(existedAuthority.getId())).isTrue();

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -82,10 +82,10 @@ class RdfImportIT {
     var resultActions = mockMvc.perform(requestBuilder);
 
     // then
-    var response = resultActions
+    resultActions
       .andExpect(status().isOk())
-      .andReturn().getResponse().getContentAsString();
-    assertThat(response).isEqualTo("[" + expectedId + "]");
+      .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
+      .andExpect(jsonPath("log", containsString(Long.toString(expectedId))));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
     assertThat(resourceRepo.existsById(existedAuthority.getId())).isTrue();
     verify(eventListener).afterCreate(any());

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -2,7 +2,10 @@ package org.folio.linked.data.e2e.rdf;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.repo.ResourceRepository;
@@ -28,7 +31,7 @@ class RdfImportIT {
     // given
     var input = this.getClass().getResourceAsStream("/rdf/instance.json");
     var multipartFile = new MockMultipartFile("fileName", "instance.json",
-      "application/ld+json", input);
+      "application/json", input);
     var requestBuilder = MockMvcRequestBuilders.multipart(IMPORT_ENDPOINT)
       .file(multipartFile)
       .headers(defaultHeaders(env));
@@ -38,10 +41,10 @@ class RdfImportIT {
     var resultActions = mockMvc.perform(requestBuilder);
 
     // then
-    var response = resultActions
+    resultActions
       .andExpect(status().isOk())
-      .andReturn().getResponse().getContentAsString();
-    assertThat(response).isEqualTo("[" + expectedId + "]");
+      .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
+      .andExpect(jsonPath("log", contains(expectedId)));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
   }
 

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -2,10 +2,10 @@ package org.folio.linked.data.e2e.rdf;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.contains;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.repo.ResourceRepository;

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfImportIT.java
@@ -44,7 +44,7 @@ class RdfImportIT {
     resultActions
       .andExpect(status().isOk())
       .andExpect(jsonPath("resources[0]", equalTo(expectedId)))
-      .andExpect(jsonPath("log", contains(expectedId)));
+      .andExpect(jsonPath("log", contains(Long.toString(expectedId))));
     assertThat(resourceRepo.existsById(expectedId)).isTrue();
   }
 

--- a/src/test/java/org/folio/linked/data/service/rdf/RdfImportServiceTest.java
+++ b/src/test/java/org/folio/linked/data/service/rdf/RdfImportServiceTest.java
@@ -68,7 +68,7 @@ class RdfImportServiceTest {
     var result = rdfImportService.importFile(multipartFile);
 
     // then
-    assertThat(result).hasSize(1);
+    assertThat(result.getResources()).hasSize(1);
     verify(metadataService).ensure(entity);
     verify(applicationEventPublisher).publishEvent(any(ResourceCreatedEvent.class));
   }
@@ -89,7 +89,7 @@ class RdfImportServiceTest {
     var result = rdfImportService.importFile(multipartFile);
 
     // then
-    assertThat(result).isEmpty();
+    assertThat(result.getResources()).isEmpty();
     verify(resourceGraphService, never()).saveMergingGraph(any());
     verify(applicationEventPublisher, never()).publishEvent(any());
   }

--- a/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
+++ b/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
@@ -1,0 +1,54 @@
+package org.folio.linked.data.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class ImportUtilsTest {
+  @ParameterizedTest
+  @CsvSource({
+    "application/json,application/ld+json",
+    "application/ld+json,application/ld+json",
+    "text/plain,text/turtle",
+    "application/xml,application/xml",
+    "application/rdf+xml,application/rdf+xml",
+    "image/png,image/png",
+    ",",
+  })
+  void toRdfMediaType_shouldReturnUpdatedMediaType(String original, String expected) {
+    assertThat(ImportUtils.toRdfMediaType(original)).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> resources() {
+    return Stream.of(
+      Arguments.of(
+        new ImportUtils.ImportedResource(1L, "", ImportUtils.Status.SUCCESS, ""),
+        "URI,LABEL,STATUS,FAILURE_REASON\r\n1,,Success,\r\n"
+      ),
+      Arguments.of(
+        new ImportUtils.ImportedResource(6920945L, "Some complexity, isn't \"missing\"", ImportUtils.Status.SUCCESS, ""),
+        "URI,LABEL,STATUS,FAILURE_REASON\r\n6920945,\"Some complexity, isn't \"\"missing\"\"\",Success,\r\n"
+      ),
+      Arguments.of(
+        new ImportUtils.ImportedResource(5L, "No good", ImportUtils.Status.FAILURE, "Some, error"),
+        "URI,LABEL,STATUS,FAILURE_REASON\r\n5,No good,Failure,\"Some, error\"\r\n"
+      )
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("resources")
+  @SneakyThrows
+  void importReportToCsv_shouldGenerateCsv(ImportUtils.ImportedResource res, String expected) {
+    var report = new ImportUtils.ImportReport();
+    report.addImport(res);
+    assertThat(report.toCsv()).isEqualTo(expected);
+  }
+}

--- a/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
+++ b/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 @UnitTest
 class ImportUtilsTest {
   @ParameterizedTest
-  @CsvSource(value={
+  @CsvSource(value = {
     "application/json,application/ld+json",
     "application/ld+json,application/ld+json",
     "text/plain,text/turtle",
@@ -22,7 +22,7 @@ class ImportUtilsTest {
     "image/png,image/png",
     "'',''",
     "null,null"
-  }, nullValues={"null"})
+  }, nullValues = {"null"})
   void toRdfMediaType_shouldReturnUpdatedMediaType(String original, String expected) {
     assertThat(ImportUtils.toRdfMediaType(original)).isEqualTo(expected);
   }

--- a/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
+++ b/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
@@ -13,15 +13,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 @UnitTest
 class ImportUtilsTest {
   @ParameterizedTest
-  @CsvSource({
+  @CsvSource(value={
     "application/json,application/ld+json",
     "application/ld+json,application/ld+json",
     "text/plain,text/turtle",
     "application/xml,application/xml",
     "application/rdf+xml,application/rdf+xml",
     "image/png,image/png",
-    ",",
-  })
+    "'',''",
+    "null,null"
+  }, nullValues={"null"})
   void toRdfMediaType_shouldReturnUpdatedMediaType(String original, String expected) {
     assertThat(ImportUtils.toRdfMediaType(original)).isEqualTo(expected);
   }

--- a/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
+++ b/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
@@ -33,8 +33,8 @@ class ImportUtilsTest {
         "URI,LABEL,STATUS,FAILURE_REASON\r\n1,,Success,\r\n"
       ),
       Arguments.of(
-        new ImportUtils.ImportedResource(6920945L, "Some complexity, isn't \"missing\"", ImportUtils.Status.SUCCESS, ""),
-        "URI,LABEL,STATUS,FAILURE_REASON\r\n6920945,\"Some complexity, isn't \"\"missing\"\"\",Success,\r\n"
+        new ImportUtils.ImportedResource(692094L, "Some complexity, isn't \"missing\"", ImportUtils.Status.SUCCESS, ""),
+        "URI,LABEL,STATUS,FAILURE_REASON\r\n692094,\"Some complexity, isn't \"\"missing\"\"\",Success,\r\n"
       ),
       Arguments.of(
         new ImportUtils.ImportedResource(5L, "No good", ImportUtils.Status.FAILURE, "Some, error"),

--- a/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
+++ b/src/test/java/org/folio/linked/data/util/ImportUtilsTest.java
@@ -30,15 +30,15 @@ class ImportUtilsTest {
     return Stream.of(
       Arguments.of(
         new ImportUtils.ImportedResource(1L, "", ImportUtils.Status.SUCCESS, ""),
-        "URI,LABEL,STATUS,FAILURE_REASON\r\n1,,Success,\r\n"
+        "ID,LABEL,STATUS,FAILURE_REASON\r\n1,,Success,\r\n"
       ),
       Arguments.of(
         new ImportUtils.ImportedResource(692094L, "Some complexity, isn't \"missing\"", ImportUtils.Status.SUCCESS, ""),
-        "URI,LABEL,STATUS,FAILURE_REASON\r\n692094,\"Some complexity, isn't \"\"missing\"\"\",Success,\r\n"
+        "ID,LABEL,STATUS,FAILURE_REASON\r\n692094,\"Some complexity, isn't \"\"missing\"\"\",Success,\r\n"
       ),
       Arguments.of(
         new ImportUtils.ImportedResource(5L, "No good", ImportUtils.Status.FAILURE, "Some, error"),
-        "URI,LABEL,STATUS,FAILURE_REASON\r\n5,No good,Failure,\"Some, error\"\r\n"
+        "ID,LABEL,STATUS,FAILURE_REASON\r\n5,No good,Failure,\"Some, error\"\r\n"
       )
     );
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLD-740

Update response to JSON containing a list of resource IDs and a CSV activity log. Also add a mechanism to convert some generic media types to rdf4j-recognized media types.