### PR TITLE
MODLD-748: Make tests run fast - Reuse JVM when running Integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,6 @@
         <version>${maven-failsafe-plugin.version}</version>
         <configuration>
           <groups>integration</groups>
-          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
 

--- a/src/test/java/org/folio/linked/data/e2e/ITBase.java
+++ b/src/test/java/org/folio/linked/data/e2e/ITBase.java
@@ -1,7 +1,8 @@
-package org.folio.linked.data.e2e.resource;
+package org.folio.linked.data.e2e;
 
 import static org.folio.linked.data.test.TestUtil.TENANT_ID;
 import static org.folio.linked.data.test.TestUtil.cleanResourceTables;
+import static org.folio.linked.data.test.TestUtil.isStandaloneTest;
 
 import org.folio.linked.data.service.resource.hash.HashService;
 import org.folio.linked.data.service.tenant.TenantScopedExecutionService;
@@ -12,7 +13,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
-abstract class AbstractResourceControllerIT {
+public abstract class ITBase {
 
   @Autowired
   protected MockMvc mockMvc;
@@ -29,8 +30,10 @@ abstract class AbstractResourceControllerIT {
 
   @BeforeEach
   public void beforeEach() {
-    tenantScopedExecutionService.execute(TENANT_ID, () ->
-      cleanResourceTables(jdbcTemplate)
-    );
+    if (isStandaloneTest(env)) {
+      cleanResourceTables(jdbcTemplate);
+    } else {
+      tenantScopedExecutionService.execute(TENANT_ID, () -> cleanResourceTables(jdbcTemplate));
+    }
   }
 }

--- a/src/test/java/org/folio/linked/data/e2e/ReIndexControllerIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/ReIndexControllerIT.java
@@ -4,9 +4,7 @@ import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.linked.data.domain.dto.ResourceIndexEventType.CREATE;
 import static org.folio.linked.data.test.MonographTestUtil.getSampleWork;
-import static org.folio.linked.data.test.TestUtil.TENANT_ID;
 import static org.folio.linked.data.test.TestUtil.awaitAndAssert;
-import static org.folio.linked.data.test.TestUtil.cleanResourceTables;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -21,8 +19,6 @@ import org.folio.linked.data.repo.ResourceEdgeRepository;
 import org.folio.linked.data.repo.ResourceRepository;
 import org.folio.linked.data.service.tenant.TenantScopedExecutionService;
 import org.folio.linked.data.test.kafka.KafkaSearchWorkIndexTopicListener;
-import org.folio.spring.tools.kafka.KafkaAdminService;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +27,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
-class ReIndexControllerIT {
+class ReIndexControllerIT extends ITBase {
 
   public static final String INDEX_URL = "/linked-data/reindex";
 
@@ -50,16 +46,10 @@ class ReIndexControllerIT {
   @Autowired
   private TenantScopedExecutionService tenantScopedExecutionService;
 
-  @BeforeAll
-  static void beforeAll(@Autowired KafkaAdminService kafkaAdminService) {
-    kafkaAdminService.createTopics(TENANT_ID);
-  }
-
   @BeforeEach
+  @Override
   public void beforeEach() {
-    tenantScopedExecutionService.execute(TENANT_ID, () ->
-      cleanResourceTables(jdbcTemplate)
-    );
+    super.beforeEach();
     consumer.getMessages().clear();
   }
 

--- a/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
@@ -10,26 +10,21 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
 import org.folio.linked.data.test.resource.ResourceTestService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @IntegrationTest
 @ActiveProfiles({STANDALONE_PROFILE, STANDALONE_TEST_PROFILE})
-class BookFormatIT {
+class BookFormatIT extends ITBase {
   static final String RESOURCE_URL = "/linked-data/resource";
 
-  @Autowired
-  protected MockMvc mockMvc;
-  @Autowired
-  protected Environment env;
   @Autowired
   protected ResourceTestService resourceService;
 

--- a/src/test/java/org/folio/linked/data/e2e/resource/AuthorityUpdateAndReadWorkIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/AuthorityUpdateAndReadWorkIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.ld.dictionary.PropertyDictionary;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
@@ -38,21 +39,15 @@ import org.folio.linked.data.repo.ResourceEdgeRepository;
 import org.folio.linked.data.service.resource.marc.ResourceMarcAuthorityService;
 import org.folio.linked.data.service.tenant.TenantScopedExecutionService;
 import org.folio.linked.data.test.MonographTestUtil;
-import org.folio.linked.data.test.kafka.KafkaSearchWorkIndexTopicListener;
 import org.folio.linked.data.test.resource.ResourceTestRepository;
-import org.folio.spring.tools.kafka.KafkaAdminService;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
 import org.springframework.data.domain.Pageable;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
-class AuthorityUpdateAndReadWorkIT {
+class AuthorityUpdateAndReadWorkIT extends ITBase {
 
   @Autowired
   private ResourceEdgeRepository resourceEdgeRepository;
@@ -61,32 +56,11 @@ class AuthorityUpdateAndReadWorkIT {
   @Autowired
   private TenantScopedExecutionService tenantScopedExecutionService;
   @Autowired
-  private KafkaSearchWorkIndexTopicListener kafkaSearchWorkIndexTopicListener;
-  @Autowired
   private ResourceTestRepository resourceTestRepository;
   @MockitoSpyBean
   @Autowired
   private ResourceMarcAuthorityService resourceMarcService;
-  @Autowired
-  private Environment env;
-  @Autowired
-  private MockMvc mockMvc;
 
-  @BeforeAll
-  static void beforeAll(@Autowired KafkaAdminService kafkaAdminService) {
-    kafkaAdminService.createTopics(TENANT_ID);
-  }
-
-  @BeforeEach
-  public void clean() {
-    tenantScopedExecutionService.execute(TENANT_ID,
-      () -> {
-        resourceEdgeRepository.deleteAll();
-        resourceTestRepository.deleteAll();
-        kafkaSearchWorkIndexTopicListener.getMessages().clear();
-      }
-    );
-  }
 
   @Test
   void authorityUpdate_withNewFingerprint_shouldLinkItToPreviousAndReturnAsWorkActiveAuthority() throws Exception {

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerBaseValidationIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerBaseValidationIT.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.folio.linked.data.domain.dto.Error;
 import org.folio.linked.data.domain.dto.ErrorResponse;
 import org.folio.linked.data.domain.dto.Parameter;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.spring.tools.kafka.KafkaAdminService;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @IntegrationTest
-class ResourceControllerBaseValidationIT extends AbstractResourceControllerIT {
+class ResourceControllerBaseValidationIT extends ITBase {
 
   @Autowired
   private ObjectMapper objectMapper;

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerIT.java
@@ -1,6 +1,5 @@
 package org.folio.linked.data.e2e.resource;
 
-import static org.folio.linked.data.test.TestUtil.TENANT_ID;
 import static org.folio.linked.data.test.TestUtil.awaitAndAssert;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,8 +17,6 @@ import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.test.kafka.KafkaInventoryTopicListener;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
 import org.folio.linked.data.test.kafka.KafkaSearchWorkIndexTopicListener;
-import org.folio.spring.tools.kafka.KafkaAdminService;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,17 +35,12 @@ class ResourceControllerIT extends ResourceControllerITBase {
   @MockitoSpyBean
   private WorkDeleteMessageSender deleteEventProducer;
 
-  @BeforeAll
-  static void beforeAll(@Autowired KafkaAdminService kafkaAdminService) {
-    kafkaAdminService.createTopics(TENANT_ID);
-  }
-
   @BeforeEach
   @Override
   public void beforeEach() {
+    super.beforeEach();
     searchIndexTopicListener.getMessages().clear();
     inventoryTopicListener.getMessages().clear();
-    tenantScopedExecutionService.execute(TENANT_ID, super::beforeEach);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
@@ -133,7 +133,6 @@ import static org.folio.linked.data.test.TestUtil.INSTANCE_WITH_WORK_REF_SAMPLE;
 import static org.folio.linked.data.test.TestUtil.OBJECT_MAPPER;
 import static org.folio.linked.data.test.TestUtil.WORK_WITH_INSTANCE_REF_SAMPLE;
 import static org.folio.linked.data.test.TestUtil.assertResourceMetadata;
-import static org.folio.linked.data.test.TestUtil.cleanResourceTables;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
 import static org.folio.linked.data.test.TestUtil.defaultHeadersWithUserId;
 import static org.folio.linked.data.test.TestUtil.getSampleInstanceDtoMap;
@@ -291,6 +290,7 @@ import org.folio.linked.data.domain.dto.InstanceResponseField;
 import org.folio.linked.data.domain.dto.ResourceIndexEventType;
 import org.folio.linked.data.domain.dto.ResourceResponseDto;
 import org.folio.linked.data.domain.dto.WorkResponseField;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.PredicateEntity;
 import org.folio.linked.data.model.entity.Resource;
@@ -304,7 +304,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
-abstract class ResourceControllerITBase extends AbstractResourceControllerIT {
+abstract class ResourceControllerITBase extends ITBase {
 
   static final String RESOURCE_URL = "/linked-data/resource";
   static final String WORK_ID_PLACEHOLDER = "%WORK_ID%";
@@ -320,7 +320,7 @@ abstract class ResourceControllerITBase extends AbstractResourceControllerIT {
   @BeforeEach
   @Override
   public void beforeEach() {
-    cleanResourceTables(jdbcTemplate);
+    super.beforeEach();
     lookupResources = saveLookupResources();
   }
 

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerInventoryIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerInventoryIT.java
@@ -12,11 +12,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.UUID;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.junit.jupiter.api.Test;
 
 @IntegrationTest
-class ResourceControllerInventoryIT extends AbstractResourceControllerIT {
+class ResourceControllerInventoryIT extends ITBase {
 
   @Test
   void getResourceIdByResourceInventoryId_shouldReturnResourceId() throws Exception {

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnPatternValidationIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnPatternValidationIT.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import org.folio.linked.data.client.SearchClient;
 import org.folio.linked.data.client.SpecClient;
 import org.folio.linked.data.domain.dto.SearchResponseTotalOnly;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -36,7 +37,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
-class ResourceControllerLccnPatternValidationIT extends AbstractResourceControllerIT {
+class ResourceControllerLccnPatternValidationIT extends ITBase {
 
   @MockitoBean
   private SpecClient specClient;

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnUniquenessValidationIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnUniquenessValidationIT.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.LinkedHashMap;
 import org.folio.linked.data.client.SearchClient;
 import org.folio.linked.data.domain.dto.SearchResponseTotalOnly;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.service.SettingsService;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
@@ -36,7 +37,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 @SpringBootTest(classes = {KafkaProducerTestConfiguration.class})
-class ResourceControllerLccnUniquenessValidationIT extends AbstractResourceControllerIT {
+class ResourceControllerLccnUniquenessValidationIT extends ITBase {
 
   private static final String LCCN_VALIDATION_NOT_AVAILABLE =
     "[Could not validate LCCN for duplicate] - reason: [Unable to reach search service]. Please try later.";

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerMarcPreviewIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerMarcPreviewIT.java
@@ -11,11 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.junit.jupiter.api.Test;
 
 @IntegrationTest
-class ResourceControllerMarcPreviewIT extends AbstractResourceControllerIT {
+class ResourceControllerMarcPreviewIT extends ITBase {
 
   @Test
   void getResourceViewById_shouldReturnInstance() throws Exception {

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerRetainOutgoingEdgesIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerRetainOutgoingEdgesIT.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.linked.data.domain.dto.InstanceResponseField;
 import org.folio.linked.data.domain.dto.ResourceResponseDto;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
@@ -33,7 +34,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @IntegrationTest
 @SpringBootTest(classes = {KafkaProducerTestConfiguration.class})
-class ResourceControllerRetainOutgoingEdgesIT extends AbstractResourceControllerIT {
+class ResourceControllerRetainOutgoingEdgesIT extends ITBase {
 
   @Test
   void shouldRetainAdminMetadataOfInstanceAfterUpdate() throws Exception {

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerSrsIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerSrsIT.java
@@ -17,6 +17,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.folio.linked.data.client.SrsClient;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.test.TestUtil;
 import org.folio.rest.jaxrs.model.ParsedRecord;
@@ -27,7 +28,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
-class ResourceControllerSrsIT extends AbstractResourceControllerIT {
+class ResourceControllerSrsIT extends ITBase {
 
   @MockitoBean
   private SrsClient srsClient;

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerUpdateInstanceIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerUpdateInstanceIT.java
@@ -12,32 +12,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.ld.dictionary.ResourceTypeDictionary;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
-import org.folio.linked.data.service.resource.hash.HashService;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
 import org.folio.linked.data.test.resource.ResourceTestService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.env.Environment;
-import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
 @SpringBootTest(classes = {KafkaProducerTestConfiguration.class})
-class ResourceControllerUpdateInstanceIT {
+class ResourceControllerUpdateInstanceIT extends ITBase {
   @Autowired
   private ResourceTestService resourceTestService;
   @Autowired
   private ObjectMapper objectMapper;
-  @Autowired
-  private HashService hashService;
-  @Autowired
-  private Environment env;
-  @Autowired
-  private MockMvc mockMvc;
 
   @Test
   void update_should_reject_if_instance_with_same_id_exists_and_connected_to_different_work() throws Exception {

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerUpdateWorkIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerUpdateWorkIT.java
@@ -14,43 +14,37 @@ import lombok.SneakyThrows;
 import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.ld.dictionary.ResourceTypeDictionary;
 import org.folio.linked.data.domain.dto.InstanceIngressEvent;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
-import org.folio.linked.data.service.resource.hash.HashService;
 import org.folio.linked.data.test.kafka.KafkaInventoryTopicListener;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
 import org.folio.linked.data.test.resource.ResourceTestService;
 import org.folio.marc4ld.service.marc2ld.reader.MarcReaderProcessor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.marc4j.marc.DataField;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.env.Environment;
-import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
 @SpringBootTest(classes = {KafkaProducerTestConfiguration.class})
-class ResourceControllerUpdateWorkIT {
+class ResourceControllerUpdateWorkIT extends ITBase {
   @Autowired
   private ResourceTestService resourceTestService;
   @Autowired
   private ObjectMapper objectMapper;
   @Autowired
-  private HashService hashService;
-  @Autowired
-  private Environment env;
-  @Autowired
-  private MockMvc mockMvc;
-  @Autowired
   private KafkaInventoryTopicListener inventoryTopicListener;
   @Autowired
   private MarcReaderProcessor marcReader;
 
-  @AfterEach
-  void clenUp() {
+  @BeforeEach
+  @Override
+  public void beforeEach() {
+    super.beforeEach();
     inventoryTopicListener.getMessages().clear();
   }
 

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceGraphControllerIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceGraphControllerIT.java
@@ -5,8 +5,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.NAME;
 import static org.folio.ld.dictionary.PropertyDictionary.PROVIDER_DATE;
 import static org.folio.ld.dictionary.PropertyDictionary.SIMPLE_PLACE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PROVIDER_EVENT;
-import static org.folio.linked.data.test.TestUtil.TENANT_ID;
-import static org.folio.linked.data.test.TestUtil.cleanResourceTables;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,25 +20,22 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.folio.linked.data.domain.dto.ResourceGraphDto;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.service.tenant.TenantScopedExecutionService;
 import org.folio.linked.data.test.MonographTestUtil;
 import org.folio.linked.data.test.resource.ResourceTestService;
 import org.folio.spring.tools.kafka.KafkaAdminService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @IntegrationTest
-class ResourceGraphControllerIT {
+class ResourceGraphControllerIT extends ITBase {
 
-  @Autowired
-  private JdbcTemplate jdbcTemplate;
   @Autowired
   private ResourceTestService resourceTestService;
   @Autowired
@@ -53,13 +48,6 @@ class ResourceGraphControllerIT {
   private TenantScopedExecutionService tenantScopedExecutionService;
   @MockitoSpyBean
   private KafkaAdminService kafkaAdminService;
-
-  @BeforeEach
-  public void clean() {
-    tenantScopedExecutionService.execute(TENANT_ID, () ->
-      cleanResourceTables(jdbcTemplate)
-    );
-  }
 
   @Test
   void getResourceGraphById_shouldReturnResourceGraph() throws Exception {

--- a/src/test/java/org/folio/linked/data/test/TestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/TestUtil.java
@@ -99,11 +99,15 @@ public class TestUtil {
   public static HttpHeaders defaultHeaders(Environment env) {
     var httpHeaders = new HttpHeaders();
     httpHeaders.setContentType(APPLICATION_JSON);
-    if (!asList(env.getActiveProfiles()).contains(STANDALONE_PROFILE)) {
+    if (!isStandaloneTest(env)) {
       httpHeaders.add(TENANT, TENANT_ID);
       httpHeaders.add(URL, getProperty(FOLIO_OKAPI_URL));
     }
     return httpHeaders;
+  }
+
+  public static boolean isStandaloneTest(Environment env) {
+    return asList(env.getActiveProfiles()).contains(STANDALONE_PROFILE);
   }
 
   public static HttpHeaders defaultHeadersWithUserId(Environment env, String value) {


### PR DESCRIPTION
This update cuts test execution time in half.

**Before change:** Tests took ~25 minutes
**After the change:** Tests now complete in 12–13 minutes


I ran the build several times & build pass all the time.