### PR TITLE
MODLD-749: Move tests for Creator and TargetAudience out of ResourceControllerITBase

### DIFF
--- a/src/test/java/org/folio/linked/data/e2e/mappings/PostResourceIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/PostResourceIT.java
@@ -1,0 +1,86 @@
+package org.folio.linked.data.e2e.mappings;
+
+import static org.folio.linked.data.test.TestUtil.STANDALONE_TEST_PROFILE;
+import static org.folio.linked.data.test.TestUtil.defaultHeaders;
+import static org.folio.linked.data.util.Constants.STANDALONE_PROFILE;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.UnsupportedEncodingException;
+import org.folio.linked.data.e2e.base.IntegrationTest;
+import org.folio.linked.data.model.entity.Resource;
+import org.folio.linked.data.test.resource.ResourceTestService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@IntegrationTest
+@ActiveProfiles({STANDALONE_PROFILE, STANDALONE_TEST_PROFILE})
+public abstract class PostResourceIT {
+  static final String RESOURCE_URL = "/linked-data/resource";
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private Environment env;
+  @Autowired
+  private ResourceTestService resourceService;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @Test
+  void testPostRequest() throws Exception {
+    // given
+    var requestPayload = postPayload();
+
+    var postRequest = post(RESOURCE_URL)
+      .contentType(APPLICATION_JSON)
+      .headers(defaultHeaders(env))
+      .content(requestPayload);
+
+    // when
+    var postResponse = mockMvc.perform(postRequest);
+
+    // then
+    validateApiResponse(postResponse);
+    var instanceId = getResourceId(postResponse);
+    var instance = resourceService.getResourceById(instanceId, 3);
+    validateGraph(instance);
+
+    var getRequest = get(RESOURCE_URL + "/" + instanceId)
+      .contentType(APPLICATION_JSON)
+      .headers(defaultHeaders(env));
+    var getResponse = mockMvc.perform(getRequest);
+    validateApiResponse(getResponse);
+  }
+
+  private String getResourceId(ResultActions postResponse) {
+    try {
+      var postResponseContent = postResponse.andReturn().getResponse().getContentAsString();
+      var jsonNode = objectMapper.readTree(postResponseContent);
+
+      var instanceOrWorkNode = jsonNode.path("resource")
+        .path("http://bibfra.me/vocab/lite/Instance").isMissingNode()
+        ? jsonNode.path("resource").path("http://bibfra.me/vocab/lite/Work")
+        : jsonNode.path("resource").path("http://bibfra.me/vocab/lite/Instance");
+
+      return instanceOrWorkNode.path("id").asText();
+
+    } catch (JsonProcessingException | UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected abstract String postPayload();
+
+  protected void validateApiResponse(ResultActions apiResponse) throws Exception {
+  }
+
+  protected void validateGraph(Resource resource){
+  }
+}

--- a/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/bookformat/BookFormatIT.java
@@ -2,59 +2,24 @@ package org.folio.linked.data.e2e.mappings.bookformat;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.linked.data.test.TestUtil.STANDALONE_TEST_PROFILE;
-import static org.folio.linked.data.test.TestUtil.defaultHeaders;
 import static org.folio.linked.data.util.Constants.STANDALONE_PROFILE;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
+import org.folio.linked.data.e2e.mappings.PostResourceIT;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
-import org.folio.linked.data.test.resource.ResourceTestService;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.ResultActions;
 
 @IntegrationTest
 @ActiveProfiles({STANDALONE_PROFILE, STANDALONE_TEST_PROFILE})
-class BookFormatIT extends ITBase {
+class BookFormatIT extends PostResourceIT {
   static final String RESOURCE_URL = "/linked-data/resource";
 
-  @Autowired
-  protected ResourceTestService resourceService;
-
-  @Test
-  void postResource_shouldCreateBookFormat() throws Exception {
-    // given
-    var requestPayload = postInstanceApiRequest();
-    var expectedInstanceId = -7766153465587539469L;
-
-    var postRequest = post(RESOURCE_URL)
-      .contentType(APPLICATION_JSON)
-      .headers(defaultHeaders(env))
-      .content(requestPayload);
-
-    // when
-    var postResponse = mockMvc.perform(postRequest);
-
-    // then
-    validateApiResponse(postResponse);
-
-    validateGraph(expectedInstanceId);
-
-    var getRequest = get(RESOURCE_URL + "/" + expectedInstanceId)
-      .contentType(APPLICATION_JSON)
-      .headers(defaultHeaders(env));
-    var getResponse = mockMvc.perform(getRequest);
-    validateApiResponse(getResponse);
-  }
-
-  private String postInstanceApiRequest() {
+  @Override
+  protected String postPayload() {
     return """
       {
          "resource":{
@@ -62,7 +27,7 @@ class BookFormatIT extends ITBase {
                "http://bibfra.me/vocab/marc/title":[
                   {
                      "http://bibfra.me/vocab/marc/Title":{
-                        "http://bibfra.me/vocab/marc/mainTitle":[ "title" ]
+                        "http://bibfra.me/vocab/marc/mainTitle":[ "%s" ]
                      }
                   }
                ],
@@ -76,10 +41,12 @@ class BookFormatIT extends ITBase {
                ]
             }
          }
-      }""";
+      }"""
+      .formatted("TEST: " + this.getClass().getSimpleName());
   }
 
-  private void validateApiResponse(ResultActions apiResponse) throws Exception {
+  @Override
+  protected void validateApiResponse(ResultActions apiResponse) throws Exception {
     var bookFormatPath = "$.resource['http://bibfra.me/vocab/lite/Instance']['http://bibfra.me/vocab/marc/bookFormat']";
     apiResponse
       .andExpect(status().isOk())
@@ -96,11 +63,10 @@ class BookFormatIT extends ITBase {
           .value("http://id.loc.gov/vocabulary/bookformat/128mo"));
   }
 
-  private void validateGraph(long instanceId) {
+  @Override
+  protected void validateGraph(Resource instance) {
     var expectedBookFormatId = 1710735011707999802L;
     var expectedCategorySetId = -5037749211942465056L;
-    var instance = resourceService.getResourceById(instanceId + "", 3);
-    assertThat(instance.getId()).isEqualTo(instanceId);
     assertThat(getProperty(instance, "http://bibfra.me/vocab/marc/bookFormat"))
       .isEqualTo("non-standard-format");
 

--- a/src/test/java/org/folio/linked/data/e2e/mappings/creator/WorkCreatorIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/creator/WorkCreatorIT.java
@@ -1,0 +1,129 @@
+package org.folio.linked.data.e2e.mappings.creator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.folio.ld.dictionary.ResourceTypeDictionary;
+import org.folio.linked.data.e2e.mappings.PostResourceIT;
+import org.folio.linked.data.model.entity.FolioMetadata;
+import org.folio.linked.data.model.entity.Resource;
+import org.folio.linked.data.model.entity.ResourceTypeEntity;
+import org.folio.linked.data.test.resource.ResourceTestService;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+class WorkCreatorIT extends PostResourceIT {
+  @Autowired
+  private ResourceTestService resourceTestService;
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void createAuthority() {
+    saveResource(1L, "John Doe", ResourceTypeDictionary.PERSON, "srsId1");
+    saveResource(2L, "John Doe Society", ResourceTypeDictionary.ORGANIZATION, "srsId2");
+    saveResource(3L, "John Doe Family", ResourceTypeDictionary.FAMILY, "srsId3");
+  }
+
+  @Override
+  protected String postPayload() {
+    return """
+      {
+         "resource":{
+            "http://bibfra.me/vocab/lite/Work":{
+               "http://bibfra.me/vocab/marc/title":[
+                  {
+                     "http://bibfra.me/vocab/marc/Title":{
+                        "http://bibfra.me/vocab/marc/mainTitle":[ "%s" ]
+                     }
+                  }
+               ],
+               "_creatorReference":[
+                  {
+                     "srsId":"srsId1",
+                     "roles":[ "http://bibfra.me/vocab/relation/author", "http://bibfra.me/vocab/relation/editor" ]
+                  }
+               ],
+               "_contributorReference":[
+                  {
+                     "id":"2",
+                     "roles":[ "http://bibfra.me/vocab/relation/funder" ]
+                  },
+                  { "srsId":"srsId3" }
+               ]
+            }
+         }
+      }"""
+      .formatted("TEST: " + this.getClass().getSimpleName());
+  }
+
+  @Override
+  protected void validateGraph(Resource work) {
+    var creator = getFirstOutgoingResource(work, "http://bibfra.me/vocab/lite/creator");
+    assertThat(creator.getId()).isEqualTo(1L);
+    assertThat(creator.getLabel()).isEqualTo("John Doe");
+
+    var author = getFirstOutgoingResource(work, "http://bibfra.me/vocab/relation/author");
+    var editor = getFirstOutgoingResource(work, "http://bibfra.me/vocab/relation/editor");
+    assertThat(creator).isEqualTo(author).isEqualTo(editor);
+
+    var contributors = getOutgoingResources(work, "http://bibfra.me/vocab/lite/contributor");
+    assertThat(contributors.size()).isEqualTo(2);
+    assertThat(contributors)
+      .extracting(Resource::getId, Resource::getLabel)
+      .containsExactlyInAnyOrder(
+        tuple(2L, "John Doe Society"),
+        tuple(3L, "John Doe Family")
+      );
+  }
+
+  @Override
+  @SneakyThrows
+  protected void validateApiResponse(ResultActions apiResponse) {
+    var workPath = "$.resource['http://bibfra.me/vocab/lite/Work']";
+
+    apiResponse
+      .andExpect(jsonPath(workPath + "['_creatorReference'][0]['id']").value("1"))
+      .andExpect(jsonPath(workPath + "['_creatorReference'][0]['label']").value("John Doe"))
+      .andExpect(jsonPath(workPath + "['_creatorReference'][0]['type']")
+        .value("http://bibfra.me/vocab/lite/Person"))
+      .andExpect(jsonPath(workPath + "['_creatorReference'][0]['roles']", containsInAnyOrder(
+        "http://bibfra.me/vocab/relation/author", "http://bibfra.me/vocab/relation/editor")));
+
+    apiResponse
+      .andExpect(jsonPath(workPath + "['_contributorReference'][0]['id']").value("2"))
+      .andExpect(jsonPath(workPath + "['_contributorReference'][0]['label']")
+        .value("John Doe Society"))
+      .andExpect(jsonPath(workPath + "['_contributorReference'][0]['type']")
+        .value("http://bibfra.me/vocab/lite/Organization"))
+      .andExpect(jsonPath(workPath + "['_contributorReference'][0]['roles'][0]")
+        .value("http://bibfra.me/vocab/relation/funder"));
+
+    apiResponse
+      .andExpect(jsonPath(workPath + "['_contributorReference'][1]['id']").value("3"))
+      .andExpect(jsonPath(workPath + "['_contributorReference'][1]['label']")
+        .value("John Doe Family"))
+      .andExpect(jsonPath(workPath + "['_contributorReference'][1]['type']")
+        .value("http://bibfra.me/vocab/lite/Family"));
+  }
+
+  @SneakyThrows
+  private void saveResource(Long id, String label, ResourceTypeDictionary type, String srsId) {
+    var resource = new Resource()
+      .addType(new ResourceTypeEntity().setHash(type.getHash()).setUri(type.getUri()))
+      .setDoc(objectMapper.readTree("{}"))
+      .setLabel(label)
+      .setId(id);
+    resource.setFolioMetadata(new FolioMetadata(resource).setSrsId(srsId));
+    resourceTestService.saveGraph(resource);
+  }
+
+  private Resource getFirstOutgoingResource(Resource work, String url) {
+    return getOutgoingResources(work, url).getFirst();
+  }
+}

--- a/src/test/java/org/folio/linked/data/e2e/mappings/targetaudience/TargetAudienceIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/targetaudience/TargetAudienceIT.java
@@ -2,11 +2,10 @@ package org.folio.linked.data.e2e.mappings.targetaudience;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import lombok.SneakyThrows;
 import org.folio.linked.data.e2e.mappings.PostResourceIT;
 import org.folio.linked.data.model.entity.Resource;
-import org.folio.linked.data.model.entity.ResourceEdge;
 import org.springframework.test.web.servlet.ResultActions;
 
 class TargetAudienceIT extends PostResourceIT {
@@ -39,7 +38,7 @@ class TargetAudienceIT extends PostResourceIT {
   protected void validateGraph(Resource work) {
     var expectedId = 7128309939039775870L;
     var expectedCategorySetId = 5919470580343311333L;
-    var targetAudience = getTarget(work, "http://bibfra.me/vocab/marc/targetAudience");
+    var targetAudience = getFirstOutgoingResource(work, "http://bibfra.me/vocab/marc/targetAudience");
     assertThat(targetAudience.getId()).isEqualTo(expectedId);
     assertThat(getProperty(targetAudience, "http://bibfra.me/vocab/marc/term")).isEqualTo("Primary");
     assertThat(getProperty(targetAudience, "http://bibfra.me/vocab/marc/code")).isEqualTo("b");
@@ -47,7 +46,7 @@ class TargetAudienceIT extends PostResourceIT {
       .isEqualTo("http://id.loc.gov/vocabulary/maudience/pri");
     assertThat(targetAudience.getLabel()).isEqualTo("Primary");
 
-    var categorySet = getTarget(targetAudience, "http://bibfra.me/vocab/lite/isDefinedBy");
+    var categorySet = getFirstOutgoingResource(targetAudience, "http://bibfra.me/vocab/lite/isDefinedBy");
     assertThat(categorySet.getId()).isEqualTo(expectedCategorySetId);
     assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/label")).isEqualTo("Target audience");
     assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/link"))
@@ -56,24 +55,17 @@ class TargetAudienceIT extends PostResourceIT {
   }
 
   @Override
-  protected void validateApiResponse(ResultActions apiResponse) throws Exception {
+  @SneakyThrows
+  protected void validateApiResponse(ResultActions apiResponse) {
     var audiencePath = "$.resource['http://bibfra.me/vocab/lite/Work']['http://bibfra.me/vocab/marc/targetAudience']";
     apiResponse
-      .andExpect(status().isOk())
       .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/marc/term'][0]").value("Primary"))
       .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/marc/code'][0]").value("b"))
       .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/lite/link'][0]")
         .value("http://id.loc.gov/vocabulary/maudience/pri"));
   }
 
-  private String getProperty(Resource resource, String property) {
-    return resource.getDoc().get(property).get(0).asText();
-  }
-
-  private Resource getTarget(Resource resource, String predicate) {
-    return resource.getOutgoingEdges().stream()
-      .filter(edge -> edge.getPredicate().getUri().equals(predicate))
-      .map(ResourceEdge::getTarget)
-      .findFirst().orElseThrow();
+  private Resource getFirstOutgoingResource(Resource instance, String url) {
+    return getOutgoingResources(instance, url).getFirst();
   }
 }

--- a/src/test/java/org/folio/linked/data/e2e/mappings/targetaudience/TargetAudienceIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/mappings/targetaudience/TargetAudienceIT.java
@@ -1,0 +1,79 @@
+package org.folio.linked.data.e2e.mappings.targetaudience;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.folio.linked.data.e2e.mappings.PostResourceIT;
+import org.folio.linked.data.model.entity.Resource;
+import org.folio.linked.data.model.entity.ResourceEdge;
+import org.springframework.test.web.servlet.ResultActions;
+
+class TargetAudienceIT extends PostResourceIT {
+  @Override
+  protected String postPayload() {
+    return """
+      {
+         "resource":{
+            "http://bibfra.me/vocab/lite/Work":{
+               "http://bibfra.me/vocab/marc/title":[
+                  {
+                     "http://bibfra.me/vocab/marc/Title":{
+                        "http://bibfra.me/vocab/marc/mainTitle":[ "%s" ]
+                     }
+                  }
+               ],
+               "http://bibfra.me/vocab/marc/targetAudience":[
+                  {
+                     "http://bibfra.me/vocab/marc/term":[ "Primary" ],
+                     "http://bibfra.me/vocab/lite/link":[ "http://id.loc.gov/vocabulary/maudience/pri" ]
+                  }
+               ]
+            }
+         }
+      }"""
+      .formatted("TEST: " + this.getClass().getSimpleName());
+  }
+
+  @Override
+  protected void validateGraph(Resource work) {
+    var expectedId = 7128309939039775870L;
+    var expectedCategorySetId = 5919470580343311333L;
+    var targetAudience = getTarget(work, "http://bibfra.me/vocab/marc/targetAudience");
+    assertThat(targetAudience.getId()).isEqualTo(expectedId);
+    assertThat(getProperty(targetAudience, "http://bibfra.me/vocab/marc/term")).isEqualTo("Primary");
+    assertThat(getProperty(targetAudience, "http://bibfra.me/vocab/marc/code")).isEqualTo("b");
+    assertThat(getProperty(targetAudience, "http://bibfra.me/vocab/lite/link"))
+      .isEqualTo("http://id.loc.gov/vocabulary/maudience/pri");
+    assertThat(targetAudience.getLabel()).isEqualTo("Primary");
+
+    var categorySet = getTarget(targetAudience, "http://bibfra.me/vocab/lite/isDefinedBy");
+    assertThat(categorySet.getId()).isEqualTo(expectedCategorySetId);
+    assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/label")).isEqualTo("Target audience");
+    assertThat(getProperty(categorySet, "http://bibfra.me/vocab/lite/link"))
+      .isEqualTo("http://id.loc.gov/vocabulary/maudience");
+    assertThat(categorySet.getLabel()).isEqualTo("Target audience");
+  }
+
+  @Override
+  protected void validateApiResponse(ResultActions apiResponse) throws Exception {
+    var audiencePath = "$.resource['http://bibfra.me/vocab/lite/Work']['http://bibfra.me/vocab/marc/targetAudience']";
+    apiResponse
+      .andExpect(status().isOk())
+      .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/marc/term'][0]").value("Primary"))
+      .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/marc/code'][0]").value("b"))
+      .andExpect(jsonPath(audiencePath + "[0]['http://bibfra.me/vocab/lite/link'][0]")
+        .value("http://id.loc.gov/vocabulary/maudience/pri"));
+  }
+
+  private String getProperty(Resource resource, String property) {
+    return resource.getDoc().get(property).get(0).asText();
+  }
+
+  private Resource getTarget(Resource resource, String predicate) {
+    return resource.getOutgoingEdges().stream()
+      .filter(edge -> edge.getPredicate().getUri().equals(predicate))
+      .map(ResourceEdge::getTarget)
+      .findFirst().orElseThrow();
+  }
+}

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
@@ -6,16 +6,11 @@ import static java.util.UUID.randomUUID;
 import static java.util.stream.StreamSupport.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.PredicateDictionary.ACCESS_LOCATION;
-import static org.folio.ld.dictionary.PredicateDictionary.ASSIGNEE;
-import static org.folio.ld.dictionary.PredicateDictionary.AUTHOR;
 import static org.folio.ld.dictionary.PredicateDictionary.CARRIER;
 import static org.folio.ld.dictionary.PredicateDictionary.CLASSIFICATION;
 import static org.folio.ld.dictionary.PredicateDictionary.CONTENT;
-import static org.folio.ld.dictionary.PredicateDictionary.CONTRIBUTOR;
 import static org.folio.ld.dictionary.PredicateDictionary.COPYRIGHT;
-import static org.folio.ld.dictionary.PredicateDictionary.CREATOR;
 import static org.folio.ld.dictionary.PredicateDictionary.DISSERTATION;
-import static org.folio.ld.dictionary.PredicateDictionary.EDITOR;
 import static org.folio.ld.dictionary.PredicateDictionary.EXTENT;
 import static org.folio.ld.dictionary.PredicateDictionary.FOCUS;
 import static org.folio.ld.dictionary.PredicateDictionary.GENRE;
@@ -66,7 +61,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.ISSUING_BODY;
 import static org.folio.ld.dictionary.PropertyDictionary.ITEM_NUMBER;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
 import static org.folio.ld.dictionary.PropertyDictionary.LANGUAGE_NOTE;
-import static org.folio.ld.dictionary.PropertyDictionary.LCNAF_ID;
 import static org.folio.ld.dictionary.PropertyDictionary.LINK;
 import static org.folio.ld.dictionary.PropertyDictionary.LOCAL_ID_VALUE;
 import static org.folio.ld.dictionary.PropertyDictionary.LOCATION_OF_OTHER_ARCHIVAL_MATERIAL;
@@ -99,7 +93,6 @@ import static org.folio.ld.dictionary.ResourceTypeDictionary.CATEGORY;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.CATEGORY_SET;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.CONCEPT;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.COPYRIGHT_EVENT;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.FAMILY;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.FORM;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.IDENTIFIER;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_EAN;
@@ -108,12 +101,9 @@ import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_LCCN;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_LOCAL;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_UNKNOWN;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.JURISDICTION;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.LANGUAGE_CATEGORY;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.MEETING;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ORGANIZATION;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PARALLEL_TITLE;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.PERSON;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PLACE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PROVIDER_EVENT;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.VARIANT_TITLE;
@@ -224,16 +214,6 @@ import static org.folio.linked.data.test.resource.ResourceJsonPath.toWork;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContentCode;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContentLink;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContentTerm;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContributorId;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContributorIsPreferred;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContributorLabel;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContributorRoles;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkContributorType;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkCreatorId;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkCreatorIsPreferred;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkCreatorLabel;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkCreatorRoles;
-import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkCreatorType;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkDateEnd;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkDateStart;
 import static org.folio.linked.data.test.resource.ResourceJsonPath.toWorkDeweyEdition;
@@ -627,8 +607,8 @@ abstract class ResourceControllerITBase extends ITBase {
     var work = getSampleWork(null);
     var instance = resourceTestService.saveGraph(getSampleInstanceResource(null, work));
     assertThat(resourceTestService.findById(instance.getId())).isPresent();
-    assertThat(resourceTestService.countResources()).isEqualTo(64);
-    assertThat(resourceTestService.countEdges()).isEqualTo(66);
+    assertThat(resourceTestService.countResources()).isEqualTo(54);
+    assertThat(resourceTestService.countEdges()).isEqualTo(53);
     var requestBuilder = delete(RESOURCE_URL + "/" + instance.getId())
       .contentType(APPLICATION_JSON)
       .headers(defaultHeaders(env));
@@ -639,9 +619,9 @@ abstract class ResourceControllerITBase extends ITBase {
     // then
     resultActions.andExpect(status().isNoContent());
     assertThat(resourceTestService.existsById(instance.getId())).isFalse();
-    assertThat(resourceTestService.countResources()).isEqualTo(63);
+    assertThat(resourceTestService.countResources()).isEqualTo(53);
     assertThat(resourceTestService.findEdgeById(instance.getOutgoingEdges().iterator().next().getId())).isNotPresent();
-    assertThat(resourceTestService.countEdges()).isEqualTo(47);
+    assertThat(resourceTestService.countEdges()).isEqualTo(34);
     checkSearchIndexMessage(work.getId(), UPDATE);
     checkIndexDate(work.getId().toString());
   }
@@ -651,8 +631,8 @@ abstract class ResourceControllerITBase extends ITBase {
     // given
     var existed = resourceTestService.saveGraph(getSampleWork(getSampleInstanceResource(null, null)));
     assertThat(resourceTestService.findById(existed.getId())).isPresent();
-    assertThat(resourceTestService.countResources()).isEqualTo(64);
-    assertThat(resourceTestService.countEdges()).isEqualTo(66);
+    assertThat(resourceTestService.countResources()).isEqualTo(54);
+    assertThat(resourceTestService.countEdges()).isEqualTo(53);
     var requestBuilder = delete(RESOURCE_URL + "/" + existed.getId())
       .contentType(APPLICATION_JSON)
       .headers(defaultHeaders(env));
@@ -663,7 +643,7 @@ abstract class ResourceControllerITBase extends ITBase {
     // then
     resultActions.andExpect(status().isNoContent());
     assertThat(resourceTestService.existsById(existed.getId())).isFalse();
-    assertThat(resourceTestService.countResources()).isEqualTo(63);
+    assertThat(resourceTestService.countResources()).isEqualTo(53);
     assertThat(resourceTestService.findEdgeById(existed.getOutgoingEdges().iterator().next().getId())).isNotPresent();
     assertThat(resourceTestService.countEdges()).isEqualTo(34);
     checkSearchIndexMessage(existed.getId(), DELETE);
@@ -843,22 +823,6 @@ abstract class ResourceControllerITBase extends ITBase {
         "-6468470931408362304")))
       .andExpect(jsonPath(toDissertationGrantingInstitutionLabels(workBase),
         containsInAnyOrder("granting institution 1", "granting institution 2")))
-      .andExpect(jsonPath(toWorkCreatorId(workBase), containsInAnyOrder("-603031702996824854", "4359679744172518150",
-        "-466724080127664871", "8296435493593701280", "5487607357549327916")))
-      .andExpect(jsonPath(toWorkCreatorLabel(workBase), containsInAnyOrder("name-CREATOR-MEETING",
-        "name-CREATOR-PERSON", "name-CREATOR-ORGANIZATION", "name-CREATOR-FAMILY", "name-CREATOR-JURISDICTION")))
-      .andExpect(jsonPath(toWorkCreatorType(workBase), containsInAnyOrder(MEETING.getUri(), PERSON.getUri(),
-        ORGANIZATION.getUri(), FAMILY.getUri(), JURISDICTION.getUri())))
-      .andExpect(jsonPath(toWorkCreatorRoles(workBase), equalTo(List.of(List.of(AUTHOR.getUri())))))
-      .andExpect(jsonPath(toWorkContributorId(workBase), containsInAnyOrder("-6054989039809126250",
-        "-7286109411186266518", "-4246830624125472784", "3094995075578514480", "2250127472356730540")))
-      .andExpect(jsonPath(toWorkContributorLabel(workBase), containsInAnyOrder("name-CONTRIBUTOR-ORGANIZATION",
-        "name-CONTRIBUTOR-FAMILY", "name-CONTRIBUTOR-PERSON", "name-CONTRIBUTOR-MEETING",
-        "name-CONTRIBUTOR-JURISDICTION")))
-      .andExpect(jsonPath(toWorkContributorType(workBase), containsInAnyOrder(ORGANIZATION.getUri(), FAMILY.getUri(),
-        PERSON.getUri(), MEETING.getUri(), JURISDICTION.getUri())))
-      .andExpect(jsonPath(toWorkContributorRoles(workBase), equalTo(List.of(List.of(EDITOR.getUri(),
-        ASSIGNEE.getUri())))))
       .andExpect(jsonPath(toWorkContentLink(workBase), equalTo("http://id.loc.gov/vocabulary/contentTypes/txt")))
       .andExpect(jsonPath(toWorkContentCode(workBase), equalTo("txt")))
       .andExpect(jsonPath(toWorkContentTerm(workBase), equalTo("text")))
@@ -888,8 +852,6 @@ abstract class ResourceControllerITBase extends ITBase {
 
   private void validateAuthorities(ResultActions resultActions, String workBase) throws Exception {
     resultActions
-      .andExpect(jsonPath(toWorkCreatorIsPreferred(workBase), containsInAnyOrder(true, false, false, false, false)))
-      .andExpect(jsonPath(toWorkContributorIsPreferred(workBase), containsInAnyOrder(true, false, false, false, false)))
       .andExpect(jsonPath(toWorkGenreIsPreferred(workBase), containsInAnyOrder(true, false)));
   }
 
@@ -1311,24 +1273,10 @@ abstract class ResourceControllerITBase extends ITBase {
     validateWorkGovernmentPublication(outgoingEdgeIterator.next(), work);
     validateLanguage(outgoingEdgeIterator.next(), work);
     validateDissertation(outgoingEdgeIterator.next(), work);
-    validateWorkContributor(outgoingEdgeIterator.next(), work, ORGANIZATION, CREATOR);
-    var editorEdge = outgoingEdgeIterator.next();
-    validateResourceEdge(editorEdge, work, editorEdge.getTarget(), EDITOR.getUri());
-    validateWorkContributor(outgoingEdgeIterator.next(), work, ORGANIZATION, CONTRIBUTOR);
-    var assigneeEdge = outgoingEdgeIterator.next();
-    validateResourceEdge(assigneeEdge, work, assigneeEdge.getTarget(), ASSIGNEE.getUri());
-    validateWorkContributor(outgoingEdgeIterator.next(), work, FAMILY, CREATOR);
-    validateWorkContributor(outgoingEdgeIterator.next(), work, FAMILY, CONTRIBUTOR);
     validateDdcClassification(outgoingEdgeIterator.next(), work);
     validateLcClassification(outgoingEdgeIterator.next(), work);
     validatePrimaryTitle(outgoingEdgeIterator.next(), work);
-    var authorEdge = outgoingEdgeIterator.next();
-    validateResourceEdge(authorEdge, work, authorEdge.getTarget(), AUTHOR.getUri());
-    validateWorkContributor(outgoingEdgeIterator.next(), work, PERSON, CREATOR);
     validateSubject(outgoingEdgeIterator.next(), work, lookupResources.subjects().getFirst());
-    validateWorkContributor(outgoingEdgeIterator.next(), work, PERSON, CONTRIBUTOR);
-    validateWorkContributor(outgoingEdgeIterator.next(), work, JURISDICTION, CREATOR);
-    validateWorkContributor(outgoingEdgeIterator.next(), work, JURISDICTION, CONTRIBUTOR);
     validateVariantTitle(outgoingEdgeIterator.next(), work);
     validateSubject(outgoingEdgeIterator.next(), work, lookupResources.subjects().get(1));
     validateResourceEdge(outgoingEdgeIterator.next(), work, lookupResources.genres().getFirst(), GENRE.getUri());
@@ -1338,8 +1286,6 @@ abstract class ResourceControllerITBase extends ITBase {
       GEOGRAPHIC_COVERAGE.getUri());
     validateResourceEdge(outgoingEdgeIterator.next(), work, lookupResources.geographicCoverages().getFirst(),
       GEOGRAPHIC_COVERAGE.getUri());
-    validateWorkContributor(outgoingEdgeIterator.next(), work, MEETING, CREATOR);
-    validateWorkContributor(outgoingEdgeIterator.next(), work, MEETING, CONTRIBUTOR);
     assertThat(outgoingEdgeIterator.hasNext()).isFalse();
     if (validateFullInstance) {
       var incomingEdgeIterator = work.getIncomingEdges().iterator();
@@ -1410,22 +1356,6 @@ abstract class ResourceControllerITBase extends ITBase {
     validateLiteral(categorySet, LINK.getValue(), "http://id.loc.gov/vocabulary/genreFormSchemes/rdacontent");
     validateLiteral(categorySet, LABEL.getValue(), "rdacontent");
     assertThat(categorySet.getLabel()).isEqualTo("rdacontent");
-  }
-
-  private void validateWorkContributor(ResourceEdge edge, Resource source, ResourceTypeDictionary type,
-                                       PredicateDictionary predicate) {
-    assertThat(edge.getId()).isNotNull();
-    assertThat(edge.getSource()).isEqualTo(source);
-    assertThat(edge.getPredicate().getUri()).isEqualTo(predicate.getUri());
-    var creator = edge.getTarget();
-    assertThat(creator.getId()).isEqualTo(hashService.hash(creator));
-    var types = creator.getTypes().stream().map(ResourceTypeEntity::getUri).toList();
-    assertThat(types).contains(type.getUri());
-    assertThat(creator.getDoc().get(NAME.getValue()).size()).isEqualTo(1);
-    assertThat(creator.getDoc().get(NAME.getValue()).get(0).asText()).isEqualTo("name-" + predicate + "-" + type);
-    assertThat(creator.getDoc().get(LCNAF_ID.getValue()).size()).isEqualTo(1);
-    assertThat(creator.getDoc().get(LCNAF_ID.getValue()).get(0).asText()).isEqualTo("2002801801-" + type);
-    assertThat(creator.getLabel()).isEqualTo("name-" + predicate + "-" + type);
   }
 
   private void validateWorkGovernmentPublication(ResourceEdge edge, Resource source) {
@@ -1543,28 +1473,6 @@ abstract class ResourceControllerITBase extends ITBase {
     var genre1 = saveResource(- 9064822434663187463L, "genre 1", FORM,
       "{\"http://bibfra.me/vocab/lite/name\": [\"genre 1\"]}", "8138e88f-4278-45ba-838c-816b80544f82");
     var genre2 = saveResource(- 4816872480602594231L, "genre 2", "{\"http://bibfra.me/vocab/lite/name\": [\"genre 2\"]}", FORM);
-    var creatorMeeting = saveResource(- 603031702996824854L, "name-CREATOR-MEETING", MEETING,
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CREATOR-MEETING\"], "
-        + "\"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-MEETING\"]}", "5f2220d5-ddf6-410a-a459-cd4b5e1b5ddb");
-    var creatorPerson = saveResource(4359679744172518150L, "name-CREATOR-PERSON",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CREATOR-PERSON\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-PERSON\"]}", PERSON);
-    var creatorOrganization = saveResource(- 466724080127664871L, "name-CREATOR-ORGANIZATION",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CREATOR-ORGANIZATION\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-ORGANIZATION\"]}", ORGANIZATION);
-    var creatorFamily = saveResource(8296435493593701280L, "name-CREATOR-FAMILY",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CREATOR-FAMILY\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-FAMILY\"]}", FAMILY);
-    var creatorJurisdiction = saveResource(5487607357549327916L, "name-CREATOR-JURISDICTION",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CREATOR-JURISDICTION\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-JURISDICTION\"]}", JURISDICTION);
-    var contributorMeeting = saveResource(- 7286109411186266518L, "name-CONTRIBUTOR-MEETING",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CONTRIBUTOR-MEETING\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-MEETING\"]}", MEETING);
-    var contributorPerson = saveResource(- 6054989039809126250L, "name-CONTRIBUTOR-PERSON",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CONTRIBUTOR-PERSON\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-PERSON\"]}", PERSON);
-    var contributorOrganization = saveResource(- 4246830624125472784L, "name-CONTRIBUTOR-ORGANIZATION", ORGANIZATION,
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CONTRIBUTOR-ORGANIZATION\"], "
-        + "\"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-ORGANIZATION\"]}", "dad61944-17d2-4ade-afc5-ad4ce318a70b");
-    var contributorFamily = saveResource(3094995075578514480L, "name-CONTRIBUTOR-FAMILY",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CONTRIBUTOR-FAMILY\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-FAMILY\"]}", FAMILY);
-    var contributorJurisdiction = saveResource(2250127472356730540L, "name-CONTRIBUTOR-JURISDICTION",
-      "{\"http://bibfra.me/vocab/lite/name\": [\"name-CONTRIBUTOR-JURISDICTION\"], \"http://bibfra.me/vocab/marc/lcnafId\": [\"2002801801-JURISDICTION\"]}", JURISDICTION);
     var assigningAgency = saveResource(4932783899755316479L, "assigning agency", "{\"http://bibfra.me/vocab/lite/name\": [\"assigning agency\"]}", ORGANIZATION);
     var libraryOfCongress = saveResource(8752404686183471966L, "United States, Library of Congress", "{\"http://bibfra.me/vocab/lite/name\": [\"United States, Library of Congress\"]}", ORGANIZATION);
     var grantingInstitution1 = saveResource(5481852630377445080L, "granting institution 1", "{\"http://bibfra.me/vocab/lite/name\": [\"granting institution 1\"]}", ORGANIZATION);
@@ -1573,8 +1481,7 @@ abstract class ResourceControllerITBase extends ITBase {
       List.of(subjectPerson, subjectForm),
       List.of(unitedStates, europe),
       List.of(genre1, genre2),
-      List.of(creatorMeeting, creatorPerson, creatorOrganization, creatorFamily, creatorJurisdiction,
-        contributorPerson, contributorMeeting, contributorOrganization, contributorFamily, contributorJurisdiction),
+      List.of(),
       List.of(assigningAgency, libraryOfCongress),
       List.of(grantingInstitution1, grantingInstitution2)
     );

--- a/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
@@ -34,7 +34,6 @@ import static org.folio.ld.dictionary.PredicateDictionary.PE_PUBLICATION;
 import static org.folio.ld.dictionary.PredicateDictionary.PROVIDER_PLACE;
 import static org.folio.ld.dictionary.PredicateDictionary.STATUS;
 import static org.folio.ld.dictionary.PredicateDictionary.SUBJECT;
-import static org.folio.ld.dictionary.PredicateDictionary.TARGET_AUDIENCE;
 import static org.folio.ld.dictionary.PredicateDictionary.TITLE;
 import static org.folio.ld.dictionary.PropertyDictionary.ACCOMPANYING_MATERIAL;
 import static org.folio.ld.dictionary.PropertyDictionary.ADDITIONAL_PHYSICAL_FORM;
@@ -566,7 +565,6 @@ public class MonographTestUtil {
     pred2OutgoingResources.put(GOVERNMENT_PUBLICATION, List.of(governmentPublication));
     pred2OutgoingResources.put(ORIGIN_PLACE, List.of(originPlace));
     pred2OutgoingResources.put(DISSERTATION, List.of(createDissertation()));
-    pred2OutgoingResources.put(TARGET_AUDIENCE, List.of(createTargetAudience()));
     pred2OutgoingResources.put(LANGUAGE, List.of(language));
     pred2OutgoingResources.put(ILLUSTRATIONS, List.of(createIllustrations()));
     pred2OutgoingResources.put(PredicateDictionary.SUPPLEMENTARY_CONTENT, List.of(createSupplementaryContent()));
@@ -731,28 +729,6 @@ public class MonographTestUtil {
       Set.of(CATEGORY),
       pred2OutgoingResources
     ).setLabel("text");
-  }
-
-  private static Resource createTargetAudience() {
-    var categorySet = createResource(
-      Map.of(
-        LINK, List.of("http://id.loc.gov/vocabulary/maudience"),
-        LABEL, List.of("Target audience")
-      ),
-      Set.of(CATEGORY_SET),
-      emptyMap())
-      .setLabel("Target audience");
-    var pred2OutgoingResources = new LinkedHashMap<PredicateDictionary, List<Resource>>();
-    pred2OutgoingResources.put(IS_DEFINED_BY, List.of(categorySet));
-    return createResource(
-      Map.of(
-        TERM, List.of("Primary"),
-        LINK, List.of("http://id.loc.gov/vocabulary/maudience/pri"),
-        CODE, List.of("b")
-      ),
-      Set.of(CATEGORY),
-      pred2OutgoingResources
-    ).setLabel("Primary");
   }
 
   private static Resource createIllustrations() {

--- a/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
@@ -5,16 +5,11 @@ import static java.util.Map.entry;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 import static org.folio.ld.dictionary.PredicateDictionary.ACCESS_LOCATION;
-import static org.folio.ld.dictionary.PredicateDictionary.ASSIGNEE;
-import static org.folio.ld.dictionary.PredicateDictionary.AUTHOR;
 import static org.folio.ld.dictionary.PredicateDictionary.CARRIER;
 import static org.folio.ld.dictionary.PredicateDictionary.CLASSIFICATION;
 import static org.folio.ld.dictionary.PredicateDictionary.CONTENT;
-import static org.folio.ld.dictionary.PredicateDictionary.CONTRIBUTOR;
 import static org.folio.ld.dictionary.PredicateDictionary.COPYRIGHT;
-import static org.folio.ld.dictionary.PredicateDictionary.CREATOR;
 import static org.folio.ld.dictionary.PredicateDictionary.DISSERTATION;
-import static org.folio.ld.dictionary.PredicateDictionary.EDITOR;
 import static org.folio.ld.dictionary.PredicateDictionary.EXTENT;
 import static org.folio.ld.dictionary.PredicateDictionary.FOCUS;
 import static org.folio.ld.dictionary.PredicateDictionary.GENRE;
@@ -66,7 +61,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.ISSUING_BODY;
 import static org.folio.ld.dictionary.PropertyDictionary.ITEM_NUMBER;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
 import static org.folio.ld.dictionary.PropertyDictionary.LANGUAGE_NOTE;
-import static org.folio.ld.dictionary.PropertyDictionary.LCNAF_ID;
 import static org.folio.ld.dictionary.PropertyDictionary.LINK;
 import static org.folio.ld.dictionary.PropertyDictionary.LOCAL_ID_VALUE;
 import static org.folio.ld.dictionary.PropertyDictionary.LOCATION_OF_OTHER_ARCHIVAL_MATERIAL;
@@ -100,7 +94,6 @@ import static org.folio.ld.dictionary.ResourceTypeDictionary.CATEGORY;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.CATEGORY_SET;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.CONCEPT;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.COPYRIGHT_EVENT;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.FAMILY;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.FORM;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.IDENTIFIER;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_EAN;
@@ -109,9 +102,7 @@ import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_LCCN;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_LOCAL;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ID_UNKNOWN;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.JURISDICTION;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.LANGUAGE_CATEGORY;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.MEETING;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ORGANIZATION;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PARALLEL_TITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.PERSON;
@@ -375,108 +366,6 @@ public class MonographTestUtil {
   public static Resource getSampleWork(Resource linkedInstance) {
     var primaryTitle = createPrimaryTitle(null);
 
-    var creatorMeeting = createResource(
-      Map.of(
-        NAME, List.of("name-CREATOR-MEETING"),
-        LCNAF_ID, List.of("2002801801-MEETING")
-      ),
-      Set.of(MEETING),
-      emptyMap()
-    ).setLabel("name-CREATOR-MEETING")
-      .setId(-603031702996824854L);
-
-    var creatorPerson = createResource(
-      Map.of(
-        NAME, List.of("name-CREATOR-PERSON"),
-        LCNAF_ID, List.of("2002801801-PERSON"),
-        RESOURCE_PREFERRED, List.of("true")
-      ),
-      Set.of(PERSON),
-      emptyMap()
-    ).setLabel("name-CREATOR-PERSON")
-      .setId(4359679744172518150L);
-
-    var creatorOrganization = createResource(
-      Map.of(
-        NAME, List.of("name-CREATOR-ORGANIZATION"),
-        LCNAF_ID, List.of("2002801801-ORGANIZATION")
-      ),
-      Set.of(ORGANIZATION),
-      emptyMap()
-    ).setLabel("name-CREATOR-ORGANIZATION")
-      .setId(-466724080127664871L);
-
-    var creatorFamily = createResource(
-      Map.of(
-        NAME, List.of("name-CREATOR-FAMILY"),
-        LCNAF_ID, List.of("2002801801-FAMILY")
-      ),
-      Set.of(FAMILY),
-      emptyMap()
-    ).setLabel("name-CREATOR-FAMILY")
-      .setId(8296435493593701280L);
-
-    var creatorJurisdiction = createResource(
-      Map.of(
-        NAME, List.of("name-CREATOR-JURISDICTION"),
-        LCNAF_ID, List.of("2002801801-JURISDICTION")
-      ),
-      Set.of(JURISDICTION),
-      emptyMap()
-    ).setLabel("name-CREATOR-JURISDICTION")
-      .setId(5487607357549327916L);
-
-    var contributorPerson = createResource(
-      Map.of(
-        NAME, List.of("name-CONTRIBUTOR-PERSON"),
-        LCNAF_ID, List.of("2002801801-PERSON"),
-        RESOURCE_PREFERRED, List.of("true")
-      ),
-      Set.of(PERSON),
-      emptyMap()
-    ).setLabel("name-CONTRIBUTOR-PERSON")
-      .setId(-6054989039809126250L);
-
-    var contributorMeeting = createResource(
-      Map.of(
-        NAME, List.of("name-CONTRIBUTOR-MEETING"),
-        LCNAF_ID, List.of("2002801801-MEETING")
-      ),
-      Set.of(MEETING),
-      emptyMap()
-    ).setLabel("name-CONTRIBUTOR-MEETING")
-      .setId(-7286109411186266518L);
-
-    var contributorOrganization = createResource(
-      Map.of(
-        NAME, List.of("name-CONTRIBUTOR-ORGANIZATION"),
-        LCNAF_ID, List.of("2002801801-ORGANIZATION")
-      ),
-      Set.of(ORGANIZATION),
-      emptyMap()
-    ).setLabel("name-CONTRIBUTOR-ORGANIZATION")
-      .setId(-4246830624125472784L);
-
-    var contributorFamily = createResource(
-      Map.of(
-        NAME, List.of("name-CONTRIBUTOR-FAMILY"),
-        LCNAF_ID, List.of("2002801801-FAMILY")
-      ),
-      Set.of(FAMILY),
-      emptyMap()
-    ).setLabel("name-CONTRIBUTOR-FAMILY")
-      .setId(3094995075578514480L);
-
-    var contributorJurisdiction = createResource(
-      Map.of(
-        NAME, List.of("name-CONTRIBUTOR-JURISDICTION"),
-        LCNAF_ID, List.of("2002801801-JURISDICTION")
-      ),
-      Set.of(JURISDICTION),
-      emptyMap()
-    ).setLabel("name-CONTRIBUTOR-JURISDICTION")
-      .setId(2250127472356730540L);
-
     var unitedStates = createResource(
       Map.of(
         NAME, List.of("United States"),
@@ -551,13 +440,6 @@ public class MonographTestUtil {
     var pred2OutgoingResources = new LinkedHashMap<PredicateDictionary, List<Resource>>();
     pred2OutgoingResources.put(TITLE, List.of(primaryTitle, createParallelTitle(), createVariantTitle()));
     pred2OutgoingResources.put(CLASSIFICATION, List.of(createLcClassification(), createDeweyClassification()));
-    pred2OutgoingResources.put(CREATOR, List.of(creatorPerson, creatorMeeting, creatorOrganization, creatorFamily,
-      creatorJurisdiction));
-    pred2OutgoingResources.put(AUTHOR, List.of(creatorPerson));
-    pred2OutgoingResources.put(CONTRIBUTOR, List.of(contributorPerson, contributorMeeting, contributorOrganization,
-      contributorFamily, contributorJurisdiction));
-    pred2OutgoingResources.put(EDITOR, List.of(contributorOrganization));
-    pred2OutgoingResources.put(ASSIGNEE, List.of(contributorOrganization));
     pred2OutgoingResources.put(CONTENT, List.of(createContent()));
     pred2OutgoingResources.put(SUBJECT, List.of(getSubjectPersonPreferred(), getSubjectFormNotPreferred()));
     pred2OutgoingResources.put(PredicateDictionary.GEOGRAPHIC_COVERAGE, List.of(unitedStates, europe));

--- a/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
+++ b/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
@@ -491,46 +491,6 @@ public class ResourceJsonPath {
       dynamicArrayPath(GRANTING_INSTITUTION_REF), path(LABEL_PROPERTY));
   }
 
-  public static String toWorkCreatorId(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CREATOR_REF), path(ID_PROPERTY));
-  }
-
-  public static String toWorkCreatorLabel(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CREATOR_REF), path(LABEL_PROPERTY));
-  }
-
-  public static String toWorkCreatorType(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CREATOR_REF), path(TYPE_PROPERTY));
-  }
-
-  public static String toWorkCreatorRoles(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CREATOR_REF), path(ROLES_PROPERTY));
-  }
-
-  public static String toWorkCreatorIsPreferred(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CREATOR_REF), path(IS_PREFERRED_PROPERTY));
-  }
-
-  public static String toWorkContributorId(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CONTRIBUTOR_REF), path(ID_PROPERTY));
-  }
-
-  public static String toWorkContributorLabel(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CONTRIBUTOR_REF), path(LABEL_PROPERTY));
-  }
-
-  public static String toWorkContributorType(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CONTRIBUTOR_REF), path(TYPE_PROPERTY));
-  }
-
-  public static String toWorkContributorRoles(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CONTRIBUTOR_REF), path(ROLES_PROPERTY));
-  }
-
-  public static String toWorkContributorIsPreferred(String workBase) {
-    return join(".", workBase, dynamicArrayPath(CONTRIBUTOR_REF), path(IS_PREFERRED_PROPERTY));
-  }
-
   public static String toWorkContentTerm(String workBase) {
     return join(".", workBase, arrayPath(CONTENT.getUri()), arrayPath(TERM.getValue()));
   }

--- a/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
+++ b/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
@@ -16,7 +16,6 @@ import static org.folio.ld.dictionary.PredicateDictionary.PROVIDER_PLACE;
 import static org.folio.ld.dictionary.PredicateDictionary.STATUS;
 import static org.folio.ld.dictionary.PredicateDictionary.SUBJECT;
 import static org.folio.ld.dictionary.PredicateDictionary.SUPPLEMENTARY_CONTENT;
-import static org.folio.ld.dictionary.PredicateDictionary.TARGET_AUDIENCE;
 import static org.folio.ld.dictionary.PredicateDictionary.TITLE;
 import static org.folio.ld.dictionary.PropertyDictionary.ASSIGNING_SOURCE;
 import static org.folio.ld.dictionary.PropertyDictionary.CODE;
@@ -574,18 +573,6 @@ public class ResourceJsonPath {
 
   public static String toWorkGovPublicationLink(String workBase) {
     return join(".", workBase, arrayPath(GOVERNMENT_PUBLICATION.getUri()), arrayPath(LINK.getValue()));
-  }
-
-  public static String toWorkTargetAudienceCode(String workBase) {
-    return join(".", workBase, arrayPath(TARGET_AUDIENCE.getUri()), arrayPath(CODE.getValue()));
-  }
-
-  public static String toWorkTargetAudienceTerm(String workBase) {
-    return join(".", workBase, arrayPath(TARGET_AUDIENCE.getUri()), arrayPath(TERM.getValue()));
-  }
-
-  public static String toWorkTargetAudienceLink(String workBase) {
-    return join(".", workBase, arrayPath(TARGET_AUDIENCE.getUri()), arrayPath(LINK.getValue()));
   }
 
   public static String toWorkContentCode(String workBase) {

--- a/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorIT.java
+++ b/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorIT.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.persistence.RollbackException;
 import jakarta.validation.ConstraintViolationException;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.repo.ResourceRepository;
@@ -17,7 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.TransactionSystemException;
 
 @IntegrationTest
-class PrimaryTitleEntityValidatorIT {
+class PrimaryTitleEntityValidatorIT extends ITBase {
 
   @Autowired
   private ResourceRepository resourceRepository;

--- a/src/test/java/org/folio/linked/data/validation/entity/ResourcePrePersistValidationIT.java
+++ b/src/test/java/org/folio/linked/data/validation/entity/ResourcePrePersistValidationIT.java
@@ -3,6 +3,7 @@ package org.folio.linked.data.validation.entity;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
 
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.Resource;
@@ -14,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @IntegrationTest
-class ResourcePrePersistValidationIT {
+class ResourcePrePersistValidationIT extends ITBase {
   @Autowired
   private ResourceRepository resourceRepository;
   @MockitoSpyBean

--- a/src/test/resources/samples/work_and_instance_ref.json
+++ b/src/test/resources/samples/work_and_instance_ref.json
@@ -141,19 +141,6 @@
           "id": "-4816872480602594231"
         }
       ],
-      "http://bibfra.me/vocab/marc/targetAudience": [
-        {
-          "http://bibfra.me/vocab/marc/code": [
-            "b"
-          ],
-          "http://bibfra.me/vocab/marc/term": [
-            "Primary"
-          ],
-          "http://bibfra.me/vocab/lite/link": [
-            "http://id.loc.gov/vocabulary/maudience/pri"
-          ]
-        }
-      ],
       "http://bibfra.me/vocab/marc/tableOfContents": [
         "table of contents"
       ],

--- a/src/test/resources/samples/work_and_instance_ref.json
+++ b/src/test/resources/samples/work_and_instance_ref.json
@@ -210,67 +210,6 @@
           ]
         }
       ],
-      "_creatorReference": [
-        {
-          "srsId": "5f2220d5-ddf6-410a-a459-cd4b5e1b5ddb",
-          "label": "name-CREATOR-MEETING",
-          "type": "http://bibfra.me/vocab/lite/Meeting"
-        },
-        {
-          "id": "4359679744172518150",
-          "label": "name-CREATOR-PERSON",
-          "type": "http://bibfra.me/vocab/lite/Person",
-          "roles": [
-            "http://bibfra.me/vocab/relation/author"
-          ]
-        },
-        {
-          "id": "-466724080127664871",
-          "label": "name-CREATOR-ORGANIZATION",
-          "type": "http://bibfra.me/vocab/lite/Organization"
-        },
-        {
-          "id": "8296435493593701280",
-          "label": "name-CREATOR-FAMILY",
-          "type": "http://bibfra.me/vocab/lite/Family"
-        },
-        {
-          "id": "5487607357549327916",
-          "label": "name-CREATOR-JURISDICTION",
-          "type": "http://bibfra.me/vocab/lite/Jurisdiction"
-        }
-      ],
-      "_contributorReference": [
-        {
-          "srsId": "dad61944-17d2-4ade-afc5-ad4ce318a70b",
-          "label": "name-CONTRIBUTOR-ORGANIZATION",
-          "type": "http://bibfra.me/vocab/lite/Organization",
-          "roles": [
-            "http://bibfra.me/vocab/relation/editor",
-            "http://bibfra.me/vocab/relation/assignee"
-          ]
-        },
-        {
-          "id": "3094995075578514480",
-          "label": "name-CONTRIBUTOR-FAMILY",
-          "type": "http://bibfra.me/vocab/lite/Family"
-        },
-        {
-          "id": "-6054989039809126250",
-          "label": "name-CONTRIBUTOR-PERSON",
-          "type": "http://bibfra.me/vocab/lite/Person"
-        },
-        {
-          "id": "-7286109411186266518",
-          "label": "name-CONTRIBUTOR-MEETING",
-          "type": "http://bibfra.me/vocab/lite/Meeting"
-        },
-        {
-          "id": "2250127472356730540",
-          "label": "name-CONTRIBUTOR-JURISDICTION",
-          "type": "http://bibfra.me/vocab/lite/Jurisdiction"
-        }
-      ],
       "http://bibfra.me/vocab/lite/dateStart": [
         "2024"
       ],


### PR DESCRIPTION
Created an abstract test class PostResourceIT that provides a common structure for testing the `POST /resource` API. This class includes a @Test method that sends a POST request to the server and verifies the response. It contains the reusable code for constructing and sending the POST request.

Subclasses are required to implement the following abstract methods:

1. postPayload() – Returns the string payload for the POST API request.
2. validateApiResponse() – Validates the responses of both POST /resource and GET /resource/{id}.
3. validateGraph() – Verifies the Instance resource created as a result of the POST request.


Added three concrete implementations:

1. BookFormatIT – Validates book formats.
2. WorkCreatorIT – Validates creators and contributors of a work.
3. TargetAudienceIT – Validates the target audience of a work.

Removed corresponding code from ResourceControllerITBase