### PR TITLE
MODLD-748: PrimaryTitleEntityValidatorIT and ResourcePrePersistValidationIT extends ITBase

### DIFF
--- a/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorIT.java
+++ b/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorIT.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.persistence.RollbackException;
 import jakarta.validation.ConstraintViolationException;
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.repo.ResourceRepository;
@@ -17,7 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.TransactionSystemException;
 
 @IntegrationTest
-class PrimaryTitleEntityValidatorIT {
+class PrimaryTitleEntityValidatorIT extends ITBase {
 
   @Autowired
   private ResourceRepository resourceRepository;

--- a/src/test/java/org/folio/linked/data/validation/entity/ResourcePrePersistValidationIT.java
+++ b/src/test/java/org/folio/linked/data/validation/entity/ResourcePrePersistValidationIT.java
@@ -3,6 +3,7 @@ package org.folio.linked.data.validation.entity;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
 
+import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.Resource;
@@ -14,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 @IntegrationTest
-class ResourcePrePersistValidationIT {
+class ResourcePrePersistValidationIT extends ITBase {
   @Autowired
   private ResourceRepository resourceRepository;
   @MockitoSpyBean


### PR DESCRIPTION
Found that https://github.com/folio-org/mod-linked-data/pull/206 causes intermittent test failures. This PR fixes the problem.