### PR TITLE
MODLD-714: Do not validate primary title edge when Instance or Work is a Series

### DIFF
--- a/src/main/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidator.java
+++ b/src/main/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidator.java
@@ -4,12 +4,14 @@ import static java.util.Objects.nonNull;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.folio.ld.dictionary.PropertyDictionary.MAIN_TITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.SERIES;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.TITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
 import org.folio.linked.data.validation.PrimaryTitleConstraint;
@@ -18,13 +20,14 @@ public class PrimaryTitleEntityValidator implements ConstraintValidator<PrimaryT
 
   @Override
   public boolean isValid(Resource resource, ConstraintValidatorContext context) {
-    if (resource.isNotOfType(INSTANCE) && resource.isNotOfType(WORK)) {
+    if (isNotWorkOrInstance(resource) || isSeries(resource)) {
       return true;
     }
     if (isEmpty(resource.getOutgoingEdges())) {
       return false;
     }
     return resource.getOutgoingEdges().stream()
+      .filter(edge -> edge.getPredicate().getUri().equals(PredicateDictionary.TITLE.getUri()))
       .map(ResourceEdge::getTarget)
       .filter(target -> target.isOfType(TITLE) && nonNull(target.getDoc()))
       .map(Resource::getDoc)
@@ -33,5 +36,13 @@ public class PrimaryTitleEntityValidator implements ConstraintValidator<PrimaryT
 
   private boolean containsMainTitle(JsonNode doc) {
     return doc.has(MAIN_TITLE.getValue()) && !doc.get(MAIN_TITLE.getValue()).isEmpty();
+  }
+
+  private boolean isNotWorkOrInstance(Resource resource) {
+    return resource.isNotOfType(INSTANCE) && resource.isNotOfType(WORK);
+  }
+
+  private boolean isSeries(Resource resource) {
+    return resource.isOfType(SERIES);
   }
 }

--- a/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorTest.java
+++ b/src/test/java/org/folio/linked/data/validation/entity/PrimaryTitleEntityValidatorTest.java
@@ -2,12 +2,13 @@ package org.folio.linked.data.validation.entity;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.SERIES;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.TITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
 import static org.folio.linked.data.test.MonographTestUtil.createPrimaryTitle;
 
 import java.util.HashSet;
-import org.folio.linked.data.model.entity.PredicateEntity;
+import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
 import org.folio.spring.testing.type.UnitTest;
@@ -58,10 +59,38 @@ class PrimaryTitleEntityValidatorTest {
   }
 
   @Test
+  void shouldReturnTrue_ifGivenResourceIsInstanceAndSeriesWithEmptyOutgoingEdges() {
+    // given
+    var resource = new Resource()
+      .addTypes(INSTANCE, SERIES)
+      .setOutgoingEdges(new HashSet<>());
+
+    // when
+    boolean result = validator.isValid(resource, null);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldReturnTrue_ifGivenResourceIsWorkAndSeriesWithEmptyOutgoingEdges() {
+    // given
+    var resource = new Resource()
+      .addTypes(WORK, SERIES)
+      .setOutgoingEdges(new HashSet<>());
+
+    // when
+    boolean result = validator.isValid(resource, null);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
   void shouldReturnFalse_ifGivenResourceIsInstanceWithEdgesContainsNoPrimaryTitle() {
     // given
     var edges = new HashSet<ResourceEdge>();
-    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), new Resource(), new PredicateEntity())));
+    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), new Resource(), PredicateDictionary.TITLE)));
     var resource = new Resource()
       .addTypes(INSTANCE)
       .setOutgoingEdges(edges);
@@ -78,7 +107,7 @@ class PrimaryTitleEntityValidatorTest {
     // given
     var edges = new HashSet<ResourceEdge>();
     var title = new Resource().addTypes(TITLE);
-    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), title, new PredicateEntity())));
+    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), title, PredicateDictionary.TITLE)));
     var resource = new Resource()
       .addTypes(INSTANCE)
       .setOutgoingEdges(edges);
@@ -95,7 +124,7 @@ class PrimaryTitleEntityValidatorTest {
     // given
     var edges = new HashSet<ResourceEdge>();
     var title = createPrimaryTitle(1L);
-    edges.add(new ResourceEdge(new Resource(), title, new PredicateEntity()));
+    edges.add(new ResourceEdge(new Resource(), title, PredicateDictionary.TITLE));
     var resource = new Resource()
       .addTypes(INSTANCE)
       .setOutgoingEdges(edges);
@@ -138,7 +167,7 @@ class PrimaryTitleEntityValidatorTest {
   void shouldReturnFalse_ifGivenResourceIsWorkWithEdgesContainsNoPrimaryTitle() {
     // given
     var edges = new HashSet<ResourceEdge>();
-    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), new Resource(), new PredicateEntity())));
+    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), new Resource(), PredicateDictionary.TITLE)));
     var resource = new Resource()
       .addTypes(WORK)
       .setOutgoingEdges(edges);
@@ -155,7 +184,7 @@ class PrimaryTitleEntityValidatorTest {
     // given
     var edges = new HashSet<ResourceEdge>();
     var title = new Resource().addTypes(TITLE);
-    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), title, new PredicateEntity())));
+    edges.add(new ResourceEdge(new ResourceEdge(new Resource(), title, PredicateDictionary.TITLE)));
     var resource = new Resource()
       .addTypes(WORK)
       .setOutgoingEdges(edges);
@@ -172,7 +201,7 @@ class PrimaryTitleEntityValidatorTest {
     // given
     var edges = new HashSet<ResourceEdge>();
     var title = createPrimaryTitle(1L);
-    edges.add(new ResourceEdge(new Resource(), title, new PredicateEntity()));
+    edges.add(new ResourceEdge(new Resource(), title, PredicateDictionary.TITLE));
     var resource = new Resource()
       .addTypes(WORK)
       .setOutgoingEdges(edges);


### PR DESCRIPTION
The `PrimaryTitleEntityValidator.java` currently prevents saving Resource entities when the resource is of type `Work` or `Instance` and lacks a `Title` edge.

However, according to [MODLD-714](https://folio-org.atlassian.net/browse/MODLD-714), resources of types `INSTANCE + SERIES` or `WORK + SERIES` are not expected to have a Title edge. As a result, the existing validator was incorrectly blocking these valid resources.

This PR resolves that issue.