### PR TITLE
Avoid join RawMarc table

### DIFF
--- a/src/main/java/org/folio/linked/data/mapper/Ld2MarcMapperDecorator.java
+++ b/src/main/java/org/folio/linked/data/mapper/Ld2MarcMapperDecorator.java
@@ -1,0 +1,42 @@
+package org.folio.linked.data.mapper;
+
+import org.folio.ld.dictionary.model.RawMarc;
+import org.folio.ld.dictionary.model.Resource;
+import org.folio.linked.data.repo.RawMarcRepository;
+import org.folio.marc4ld.enums.UnmappedMarcHandling;
+import org.folio.marc4ld.service.ld2marc.Ld2MarcMapper;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+public class Ld2MarcMapperDecorator implements Ld2MarcMapper {
+  private final Ld2MarcMapper delegate;
+  private final RawMarcRepository rawMarcRepository;
+
+  public Ld2MarcMapperDecorator(@Qualifier("ld2MarcMapperImpl") Ld2MarcMapper delegate,
+                                RawMarcRepository rawMarcRepository) {
+    this.delegate = delegate;
+    this.rawMarcRepository = rawMarcRepository;
+  }
+
+  @Override
+  public String toMarcJson(Resource resource) {
+    enrichWithRawMarc(resource);
+    return delegate.toMarcJson(resource);
+  }
+
+  @Override
+  public String toMarcJson(Resource resource, UnmappedMarcHandling marcHandling) {
+    enrichWithRawMarc(resource);
+    return delegate.toMarcJson(resource, marcHandling);
+  }
+
+  private void enrichWithRawMarc(Resource resource) {
+    rawMarcRepository.findById(resource.getId())
+      .map(org.folio.linked.data.model.entity.RawMarc::getContent)
+      .map(rawMarcStr -> new RawMarc().setContent(rawMarcStr))
+      .ifPresent(resource::setUnmappedMarc);
+  }
+}

--- a/src/main/java/org/folio/linked/data/mapper/ResourceModelMapper.java
+++ b/src/main/java/org/folio/linked/data/mapper/ResourceModelMapper.java
@@ -16,11 +16,8 @@ import org.folio.ld.dictionary.PredicateDictionary;
 import org.folio.ld.dictionary.ResourceTypeDictionary;
 import org.folio.linked.data.model.entity.FolioMetadata;
 import org.folio.linked.data.model.entity.PredicateEntity;
-import org.folio.linked.data.model.entity.RawMarc;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceTypeEntity;
-import org.folio.linked.data.repo.RawMarcRepository;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.BeforeMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -28,13 +25,9 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Qualifier;
 import org.mapstruct.TargetType;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Mapper(componentModel = SPRING)
 public abstract class ResourceModelMapper {
-
-  @Autowired
-  private RawMarcRepository rawMarcRepository;
 
   @NotForGeneration
   public Resource toEntity(org.folio.ld.dictionary.model.Resource model) {
@@ -69,14 +62,6 @@ public abstract class ResourceModelMapper {
   @Mapping(source = "resource", target = "resource")
   protected abstract FolioMetadata mapFolioMetadata(org.folio.ld.dictionary.model.FolioMetadata folioMetadata,
                                                     Resource resource);
-
-  @AfterMapping
-  protected void setUnmappedMarc(Resource entity, @MappingTarget org.folio.ld.dictionary.model.Resource model) {
-    rawMarcRepository.findById(entity.getId())
-      .map(RawMarc::getContent)
-      .map(content -> new org.folio.ld.dictionary.model.RawMarc().setContent(content))
-      .ifPresent(model::setUnmappedMarc);
-  }
 
   @Qualifier
   @Target(ElementType.METHOD)

--- a/src/main/java/org/folio/linked/data/model/entity/RawMarc.java
+++ b/src/main/java/org/folio/linked/data/model/entity/RawMarc.java
@@ -6,14 +6,10 @@ import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 import org.hibernate.annotations.Type;
 
@@ -33,14 +29,7 @@ public class RawMarc {
   @Type(JsonBinaryType.class)
   private String content;
 
-  @OneToOne
-  @MapsId
-  @JoinColumn(name = "resource_hash")
-  @ToString.Exclude
-  private Resource resource;
-
   public RawMarc(Resource resource) {
-    this.resource = resource;
     this.id = resource.getId();
   }
 }

--- a/src/main/java/org/folio/linked/data/model/entity/Resource.java
+++ b/src/main/java/org/folio/linked/data/model/entity/Resource.java
@@ -102,10 +102,6 @@ public class Resource implements Persistable<Long> {
   @PrimaryKeyJoinColumn
   private FolioMetadata folioMetadata;
 
-  @OneToOne(cascade = ALL, mappedBy = "resource", orphanRemoval = true)
-  @PrimaryKeyJoinColumn
-  private RawMarc unmappedMarc;
-
   @Column(name = "created_date", updatable = false, nullable = false)
   private Timestamp createdDate;
 
@@ -133,7 +129,6 @@ public class Resource implements Persistable<Long> {
     this.label = that.label;
     this.doc = (JsonNode) ofNullable(that.getDoc()).map(JsonNode::deepCopy).orElse(null);
     this.folioMetadata = that.folioMetadata;
-    this.unmappedMarc = that.unmappedMarc;
     this.indexDate = that.indexDate;
     this.types = new LinkedHashSet<>(that.getTypes());
     this.createdDate = that.createdDate;

--- a/src/main/java/org/folio/linked/data/repo/RawMarcRepository.java
+++ b/src/main/java/org/folio/linked/data/repo/RawMarcRepository.java
@@ -1,0 +1,7 @@
+package org.folio.linked.data.repo;
+
+import org.folio.linked.data.model.entity.RawMarc;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RawMarcRepository extends CrudRepository<RawMarc, Long> {
+}

--- a/src/main/java/org/folio/linked/data/service/resource/copy/ResourceCopyServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/copy/ResourceCopyServiceImpl.java
@@ -21,11 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
-import org.folio.linked.data.model.entity.RawMarc;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.service.resource.edge.ResourceEdgeService;
 import org.springframework.stereotype.Service;
@@ -57,18 +55,7 @@ public class ResourceCopyServiceImpl implements ResourceCopyService {
   @Override
   public void copyEdgesAndProperties(Resource old, Resource updated) {
     resourceEdgeService.copyOutgoingEdges(old, updated);
-    copyUnmappedMarc(old, updated);
     copyProperties(old, updated);
-  }
-
-  private void copyUnmappedMarc(Resource from, Resource to) {
-    if (to.isOfType(INSTANCE)) {
-      Optional.ofNullable(from.getUnmappedMarc())
-        .ifPresent(unmappedMarc -> {
-          var newUnmappedMarc = new RawMarc(to).setContent(unmappedMarc.getContent());
-          to.setUnmappedMarc(newUnmappedMarc);
-        });
-    }
   }
 
   @SneakyThrows

--- a/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
@@ -235,7 +235,6 @@ public class ResourceMarcBibServiceImpl implements ResourceMarcBibService {
     return newResource;
   }
 
-
   private void refreshWork(Resource resource) {
     if (resource.isOfType(INSTANCE)) {
       extractWorkFromInstance(resource)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,9 +22,7 @@ spring:
         event:
           merge:
             entity_copy_observer: allow
-        format_sql: true
     open-in-view: false
-    show-sql: true
   kafka:
     bootstrap-servers: ${KAFKA_HOST:kafka}:${KAFKA_PORT:9092}
     consumer:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,9 @@ spring:
         event:
           merge:
             entity_copy_observer: allow
+        format_sql: true
     open-in-view: false
+    show-sql: true
   kafka:
     bootstrap-servers: ${KAFKA_HOST:kafka}:${KAFKA_PORT:9092}
     consumer:

--- a/src/main/resources/changelog/scripts/v-2.0.0/metadata/changelog.xml
+++ b/src/main/resources/changelog/scripts/v-2.0.0/metadata/changelog.xml
@@ -4,4 +4,5 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
   <include file="tables/upgrade_profiles_table.sql" relativeToChangelogFile="true"/>
+  <include file="tables/upgrade_raw_marcs_on_delete_cascade.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/scripts/v-2.0.0/metadata/tables/upgrade_raw_marcs_on_delete_cascade.sql
+++ b/src/main/resources/changelog/scripts/v-2.0.0/metadata/tables/upgrade_raw_marcs_on_delete_cascade.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset pkjacob@ebsco.com:3.6_raw_marcs_on_delete_cascade dbms:postgresql
+alter table raw_marcs
+drop constraint if exists raw_marcs_resource_hash_fkey;
+
+alter table raw_marcs
+  add constraint raw_marcs_resource_hash_fkey
+    foreign key (resource_hash)
+      references resources(resource_hash)
+      on delete cascade;
+
+--rollback alter table raw_marcs drop constraint if exists raw_marcs_resource_hash_fkey;

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerMarcPreviewIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerMarcPreviewIT.java
@@ -4,6 +4,7 @@ import static org.folio.linked.data.e2e.resource.ResourceControllerITBase.RESOUR
 import static org.folio.linked.data.test.MonographTestUtil.getSampleInstanceResource;
 import static org.folio.linked.data.test.TestUtil.defaultHeaders;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,15 +14,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.folio.linked.data.e2e.ITBase;
 import org.folio.linked.data.e2e.base.IntegrationTest;
+import org.folio.linked.data.model.entity.RawMarc;
+import org.folio.linked.data.repo.RawMarcRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @IntegrationTest
 class ResourceControllerMarcPreviewIT extends ITBase {
+  @Autowired
+  private RawMarcRepository rawMarcRepository;
 
   @Test
-  void getResourceViewById_shouldReturnInstance() throws Exception {
+  void shouldDeriveMarcFromGraph() throws Exception {
     // given
     var existed = resourceTestService.saveGraph(getSampleInstanceResource());
+    var unmappedMarc = """
+      {
+         "fields":[ {
+           "630":{ "subfields":[ { "a":"Unmapped field" } ] }
+         } ]
+      }""";
+    rawMarcRepository.save(new RawMarc(existed).setContent(unmappedMarc));
     var requestBuilder = get(RESOURCE_URL + "/" + existed.getId() + "/marc")
       .contentType(APPLICATION_JSON)
       .headers(defaultHeaders(env));
@@ -33,11 +46,9 @@ class ResourceControllerMarcPreviewIT extends ITBase {
     resultActions
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andReturn().getResponse().getContentAsString();
-
-    resultActions
       .andExpect(jsonPath("id", equalTo(existed.getId().toString())))
       .andExpect(jsonPath("recordType", equalTo("MARC_BIB")))
-      .andExpect(jsonPath("parsedRecord.content", notNullValue()));
+      .andExpect(jsonPath("parsedRecord.content", notNullValue()))
+      .andExpect(jsonPath("parsedRecord.content.fields[*]['630'].subfields[0].a", hasItem("Unmapped field")));
   }
 }

--- a/src/test/java/org/folio/linked/data/service/resource/copy/ResourceCopyServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/copy/ResourceCopyServiceImplTest.java
@@ -3,9 +3,6 @@ package org.folio.linked.data.service.resource.copy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.WORK;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -22,7 +19,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
-import org.folio.linked.data.model.entity.RawMarc;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceTypeEntity;
 import org.folio.linked.data.service.resource.edge.ResourceEdgeService;
@@ -53,31 +49,12 @@ class ResourceCopyServiceImplTest {
   void copyEdgesAndProperties_shouldRetainUnmappedMarc_whenUpdatedResourceIsInstance() {
     // given
     var old = new Resource();
-    var rawMarc = "raw marc";
-    old.setUnmappedMarc(new RawMarc(old).setContent(rawMarc));
     var updated = new Resource().addTypes(INSTANCE);
 
     // when
     service.copyEdgesAndProperties(old, updated);
 
     // then
-    assertNotNull(updated.getUnmappedMarc());
-    assertEquals(rawMarc, updated.getUnmappedMarc().getContent());
-    verify(resourceEdgeService).copyOutgoingEdges(old, updated);
-  }
-
-  @Test
-  void copyEdgesAndProperties_shouldNotRetainUnmappedMarc_whenUpdatedResourceIsNotInstance() {
-    // given
-    var old = new Resource();
-    old.setUnmappedMarc(new RawMarc(old).setContent("raw marc"));
-    var updated = new Resource();
-
-    // when
-    service.copyEdgesAndProperties(old, updated);
-
-    // then
-    assertNull(updated.getUnmappedMarc());
     verify(resourceEdgeService).copyOutgoingEdges(old, updated);
   }
 


### PR DESCRIPTION
Currently, the Resource table includes the following mapping:

```
@OneToOne(cascade = ALL, mappedBy = "resource", orphanRemoval = true)
@PrimaryKeyJoinColumn
private RawMarc unmappedMarc;
```

As a result, a left join to the `raw_marcs` table is always performed when a Resource is fetched. However, this join is often unnecessary, as only Instance resources have corresponding records in the raw_marcs table.

This PR removes the `unmappedMarc` field from the Resource class and handles the saving and retrieval of unmapped MARC data explicitly in code.