### PR TITLE
Use format block to create fully qualified schema references

### DIFF
--- a/src/main/resources/changelog/scripts/v-2.0.0/metadata/functions/resource_subgraph.sql
+++ b/src/main/resources/changelog/scripts/v-2.0.0/metadata/functions/resource_subgraph.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset resource_subgraph dbms:postgresql
+--changeset resource_subgraph dbms:postgresql splitStatements:false
 
 create type export_doc as (
   id       bigint,
@@ -16,213 +16,226 @@ create type export_triple as (
   depth     integer
 );
 
--- Iteratively retrieve triples from the resources and resource_edges tables
--- to the specified depth. Avoid any cycles by tracking the path to each
--- subject and stopping at either the appropriate depth or if a node is
--- repeated. Triples sharing the same subject and predicate use an array to
--- output a list of objects because Postgres JSONB aggregation does not merge
--- on shared keys but replaces instead.
-create or replace function resource_subgraph(
-  v_id bigint,
-  v_max_depth integer
-) returns setof export_triple as '
-begin
-  return query
-  with recursive subgraph(subject, predicate, object, depth, is_cycle, path) as (
-    select
-      resources.resource_hash,
-      predicate_lookup.predicate,
-      resource_edges.target_hash,
-      1,
-      false,
-      array[resources.resource_hash]
-    from
-      resources
-      inner join resource_edges
-        on resources.resource_hash = resource_edges.source_hash
-      inner join predicate_lookup
-        on resource_edges.predicate_hash = predicate_lookup.predicate_hash
-    where
-      resources.resource_hash = v_id
-    union all
-    select
-      resources.resource_hash,
-      predicate_lookup.predicate,
-      resource_edges.target_hash,
-      subgraph.depth + 1,
-      resources.resource_hash = any(subgraph.path),
-      subgraph.path || resources.resource_hash
-    from
-      resources
-      inner join resource_edges
-        on resources.resource_hash = resource_edges.source_hash
-      inner join predicate_lookup
-        on resource_edges.predicate_hash = predicate_lookup.predicate_hash
-      inner join subgraph
-        on resources.resource_hash = subgraph.object
-        and not subgraph.is_cycle
-  )
-  select
-    s.subject,
-    s.predicate,
-    array_agg(s.object) as objects,
-    s.depth
-  from
-    subgraph s
-  where
-    s.depth <= v_max_depth
-    and not s.is_cycle
-  group by
-    s.subject,
-    s.predicate,
-    s.depth;
-end ' language plpgsql;
-
--- Recursive function to expand triple objects into their own subgraph.
--- Postgres does not support nested aggregate functions, so object arrays
--- must be expanded and handled separately from the main query. Some
--- nodes do not have any outgoing edges, so a coalesce filter is used to
--- substitute an empty object for those cases, as the build object function
--- does not allow null properties.
-create or replace function export_resource_edges(
-  v_id bigint,
-  v_depth integer,
-  v_max_depth integer,
-  v_path bigint[],
-  v_docs export_doc[],
-  v_triples export_triple[]
-) returns jsonb as '
-declare
-  local_doc jsonb;
-begin
-  if v_depth = v_max_depth + 1 or v_id = any(v_path)
-  then
-    select
-      jsonb_build_object(''id'', v_id::text) into local_doc;
-  else
-  with expanded_objects as (
-    select
-      subject,
-      predicate,
-      depth,
-      array_agg(coalesce(export_resource_edges(
-        o,
-        v_depth + 1,
-        v_max_depth,
-        v_id || v_path,
-        v_docs,
-        v_triples
-      ), jsonb_build_object(''id'', o::text))) as expansion
-    from
-      (
-        select
-          s.subject,
-          s.predicate,
-          s.depth,
-          o
-        from
-          unnest(v_triples) s
-            cross join lateral unnest(s.objects) as o
-        where
-          s.subject = v_id
-        group by
-          s.subject,
-          s.predicate,
-          s.depth,
-          o
-        ) deduped
-    group by
-      subject,
-      predicate,
-      depth
-  )
-  select
-    jsonb_build_object(
-      ''id'', d.id::text,
-      ''doc'', d.doc,
-      ''label'', d.label,
-      ''types'', d.types,
-      ''outgoingEdges'', coalesce(jsonb_object_agg(
-        eos.predicate, eos.expansion
-      ) filter (where eos.predicate is not null), ''{}'')
-    ) into local_doc
-  from
-    unnest(v_docs) d
-      left outer join expanded_objects as eos
-      on d.id = eos.subject
-  where
-    d.id = v_id
-  group by
-    d.id,
-    d.label,
-    d.types,
-    d.doc;
-  end if;
-  return local_doc;
-end ' language plpgsql;
-
--- Primary function exporting a JSON subgraph starting with the given
--- subject to the specified depth.
-create or replace function export_subgraph(
-  v_id bigint,
-  v_max_depth integer
-) returns jsonb as '
-declare
-  subgraph_doc jsonb;
-begin
-  with subgraph_set as (
-    select
-      subgraph.subject,
-      subgraph.predicate,
-      subgraph.objects,
-      subgraph.depth
-    from
-      resource_subgraph(v_id, v_max_depth) as subgraph
-  ),
-  docs_set as (
-    select
-      r.resource_hash as id,
-      r.doc,
-      r.label,
-      jsonb_agg(type_lookup.type_uri) as types
-    from
-      resources r
-      inner join resource_type_map as rtm
-        on rtm.resource_hash = r.resource_hash
-      inner join type_lookup
-        on rtm.type_hash = type_lookup.type_hash
-    where
-      r.resource_hash in (
-        select
-          distinct subject
-        from
-          subgraph_set
-        union
-        select
-          distinct unnest(objects)
-        from
-          subgraph_set
-      )
-    group by
-      r.resource_hash
-  )
-  select
-    jsonb_strip_nulls(export_resource_edges(
-      v_id,
-      1,
-      v_max_depth,
-      array[]::bigint[],
-      (select array_agg(row(id, label, types, doc)::export_doc) from docs_set),
-      (select array_agg(row(subject, predicate, objects, depth)::export_triple) from subgraph_set)
-    )) into subgraph_doc;
-  return subgraph_doc;
-end ' language plpgsql;
-
 comment on type export_doc is 'Helper type to represent resource properties with literal values';
 comment on type export_triple is 'Helper type to represent resource properties with object values';
-comment on function resource_subgraph(bigint, integer) is 'Recursively export the graph starting from id, to the depth max_depth, with no cycles, as a set';
-comment on function export_resource_edges(bigint, integer, integer, bigint[], export_doc[], export_triple[]) is 'Recursive function to export as JSON a resource, its properties, and objects, calling itself on objects to a depth of max_depth, with no cycles';
-comment on function export_subgraph(bigint, integer) is 'Export resource subgraph as an aggregated JSONB document';
+
+do $do$
+  begin
+  execute format($format$
+    -- Iteratively retrieve triples from the resources and resource_edges tables
+    -- to the specified depth. Avoid any cycles by tracking the path to each
+    -- subject and stopping at either the appropriate depth or if a node is
+    -- repeated. Triples sharing the same subject and predicate use an array to
+    -- output a list of objects because Postgres JSONB aggregation does not merge
+    -- on shared keys but replaces instead.
+    create or replace function %1$I.resource_subgraph(
+      v_id bigint,
+      v_max_depth integer
+    ) returns setof %1$I.export_triple as $$
+    begin
+      return query
+      with recursive subgraph(subject, predicate, object, depth, is_cycle, path) as (
+        select
+          resources.resource_hash,
+          predicate_lookup.predicate,
+          resource_edges.target_hash,
+          1,
+          false,
+          array[resources.resource_hash]
+        from
+          %1$I.resources
+          inner join %1$I.resource_edges
+            on resources.resource_hash = resource_edges.source_hash
+          inner join %1$I.predicate_lookup
+            on resource_edges.predicate_hash = predicate_lookup.predicate_hash
+        where
+          resources.resource_hash = v_id
+        union all
+        select
+          resources.resource_hash,
+          predicate_lookup.predicate,
+          resource_edges.target_hash,
+          subgraph.depth + 1,
+          resources.resource_hash = any(subgraph.path),
+          subgraph.path || resources.resource_hash
+        from
+          %1$I.resources
+          inner join %1$I.resource_edges
+            on resources.resource_hash = resource_edges.source_hash
+          inner join %1$I.predicate_lookup
+            on resource_edges.predicate_hash = predicate_lookup.predicate_hash
+          inner join subgraph
+            on resources.resource_hash = subgraph.object
+            and not subgraph.is_cycle
+      )
+      select
+        s.subject,
+        s.predicate,
+        array_agg(s.object) as objects,
+        s.depth
+      from
+        subgraph s
+      where
+        s.depth <= v_max_depth
+        and not s.is_cycle
+      group by
+        s.subject,
+        s.predicate,
+        s.depth;
+    end $$
+    language plpgsql
+    set search_path=%1$I,public;
+
+    -- Recursive function to expand triple objects into their own subgraph.
+    -- Postgres does not support nested aggregate functions, so object arrays
+    -- must be expanded and handled separately from the main query. Some
+    -- nodes do not have any outgoing edges, so a coalesce filter is used to
+    -- substitute an empty object for those cases, as the build object function
+    -- does not allow null properties.
+    create or replace function %1$I.export_resource_edges(
+      v_id bigint,
+      v_depth integer,
+      v_max_depth integer,
+      v_path bigint[],
+      v_docs %1$I.export_doc[],
+      v_triples %1$I.export_triple[]
+    ) returns jsonb as $$
+    declare
+      local_doc jsonb;
+    begin
+      if v_depth = v_max_depth + 1 or v_id = any(v_path)
+      then
+        select
+          jsonb_build_object('id', v_id::text) into local_doc;
+      else
+      with expanded_objects as (
+        select
+          subject,
+          predicate,
+          depth,
+          array_agg(coalesce(%1$I.export_resource_edges(
+            o,
+            v_depth + 1,
+            v_max_depth,
+            v_id || v_path,
+            v_docs,
+            v_triples
+          ), jsonb_build_object('id', o::text))) as expansion
+        from
+          (
+            select
+              s.subject,
+              s.predicate,
+              s.depth,
+              o
+            from
+              unnest(v_triples) s
+                cross join lateral unnest(s.objects) as o
+            where
+              s.subject = v_id
+            group by
+              s.subject,
+              s.predicate,
+              s.depth,
+              o
+            ) deduped
+        group by
+          subject,
+          predicate,
+          depth
+      )
+      select
+        jsonb_build_object(
+          'id', d.id::text,
+          'doc', d.doc,
+          'label', d.label,
+          'types', d.types,
+          'outgoingEdges', coalesce(jsonb_object_agg(
+            eos.predicate, eos.expansion
+          ) filter (where eos.predicate is not null), '{}')
+        ) into local_doc
+      from
+        unnest(v_docs) d
+          left outer join expanded_objects as eos
+          on d.id = eos.subject
+      where
+        d.id = v_id
+      group by
+        d.id,
+        d.label,
+        d.types,
+        d.doc;
+      end if;
+      return local_doc;
+    end $$
+    language plpgsql
+    set search_path=%1$I,public;
+
+    -- Primary function exporting a JSON subgraph starting with the given
+    -- subject to the specified depth.
+    create or replace function %1$I.export_subgraph(
+      v_id bigint,
+      v_max_depth integer
+    ) returns jsonb as $$
+    declare
+      subgraph_doc jsonb;
+    begin
+      with subgraph_set as (
+        select
+          subgraph.subject,
+          subgraph.predicate,
+          subgraph.objects,
+          subgraph.depth
+        from
+          %1$I.resource_subgraph(v_id, v_max_depth) as subgraph
+      ),
+      docs_set as (
+        select
+          r.resource_hash as id,
+          r.doc,
+          r.label,
+          jsonb_agg(type_lookup.type_uri) as types
+        from
+          %1$I.resources r
+          inner join %1$I.resource_type_map as rtm
+            on rtm.resource_hash = r.resource_hash
+          inner join %1$I.type_lookup
+            on rtm.type_hash = type_lookup.type_hash
+        where
+          r.resource_hash in (
+            select
+              distinct subject
+            from
+              subgraph_set
+            union
+            select
+              distinct unnest(objects)
+            from
+              subgraph_set
+          )
+        group by
+          r.resource_hash
+      )
+      select
+        jsonb_strip_nulls(%1$I.export_resource_edges(
+          v_id,
+          1,
+          v_max_depth,
+          array[]::bigint[],
+          (select array_agg(row(id, label, types, doc)::%1$I.export_doc) from docs_set),
+          (select array_agg(row(subject, predicate, objects, depth)::%1$I.export_triple) from subgraph_set)
+        )) into subgraph_doc;
+      return subgraph_doc;
+    end $$
+    language plpgsql
+    set search_path=%1$I,public;
+
+    comment on function %1$I.resource_subgraph(bigint, integer) is 'Recursively export the graph starting from id, to the depth max_depth, with no cycles, as a set';
+    comment on function %1$I.export_resource_edges(bigint, integer, integer, bigint[], %1$I.export_doc[], %1$I.export_triple[]) is 'Recursive function to export as JSON a resource, its properties, and objects, calling itself on objects to a depth of max_depth, with no cycles';
+    comment on function %1$I.export_subgraph(bigint, integer) is 'Export resource subgraph as an aggregated JSONB document';
+  $format$, CURRENT_SCHEMA);
+  end;
+$do$;
 
 --rollback drop type if exists export_doc;
 --rollback drop type if exists export_triple;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLD-756

References between functions need to use the fully qualified schema when referring to other functions, types, and tables, instead of relying on the default search path. The visual diff is a little unhelpful; this just separates the type definitions and wraps the function definitions in a `format` call to aid with creating the appropriate reference names.
