### PR TITLE
MODLD-768: Fix: Update tests with status link

### DIFF
--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfExportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfExportIT.java
@@ -29,7 +29,6 @@ class RdfExportIT {
   @Autowired
   private ResourceTestService resourceTestService;
 
-  @Disabled("getSampleInstanceResource needs to be updated to match latest lib-linked-data-rdf4ld changes")
   @Test
   void rdfExport_shouldReturnExportedResultForExistedInstance() throws Exception {
     // given

--- a/src/test/java/org/folio/linked/data/e2e/rdf/RdfExportIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/rdf/RdfExportIT.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.folio.linked.data.e2e.base.IntegrationTest;
 import org.folio.linked.data.test.kafka.KafkaProducerTestConfiguration;
 import org.folio.linked.data.test.resource.ResourceTestService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerITBase.java
@@ -741,12 +741,12 @@ abstract class ResourceControllerITBase extends ITBase {
         .andExpect(jsonPath(toIsbnValue(), equalTo(List.of("isbn value"))))
         .andExpect(jsonPath(toIsbnQualifier(), equalTo(List.of("isbn qualifier"))))
         .andExpect(jsonPath(toIsbnStatusValue(), equalTo(List.of("isbn status value"))))
-        .andExpect(jsonPath(toIsbnStatusLink(), equalTo(List.of("isbn status link"))))
+        .andExpect(jsonPath(toIsbnStatusLink(), equalTo(List.of("http://id/isbn"))))
         .andExpect(jsonPath(toIssuance(), equalTo("single unit")))
         .andExpect(jsonPath(toStatementOfResponsibility(), equalTo("statement of responsibility")))
         .andExpect(jsonPath(toLccnValue(), equalTo(List.of("lccn value"))))
         .andExpect(jsonPath(toLccnStatusValue(), equalTo(List.of("lccn status value"))))
-        .andExpect(jsonPath(toLccnStatusLink(), equalTo(List.of("lccn status link"))))
+        .andExpect(jsonPath(toLccnStatusLink(), equalTo(List.of("http://id/lccn"))))
         .andExpect(jsonPath(toLocalIdValue(), equalTo(List.of("localId value"))))
         .andExpect(jsonPath(toLocalIdAssigner(), equalTo(List.of("localId assigner"))))
         .andExpect(jsonPath(toMediaCode(), equalTo("s")))
@@ -810,7 +810,7 @@ abstract class ResourceControllerITBase extends ITBase {
       .andExpect(jsonPath(toWorkDeweyEditionNumber(workBase), equalTo(List.of("edition number"))))
       .andExpect(jsonPath(toWorkDeweyEdition(workBase), equalTo(List.of("edition"))))
       .andExpect(jsonPath(toLcStatusValue(workBase), equalTo(List.of("lc status value"))))
-      .andExpect(jsonPath(toLcStatusLink(workBase), equalTo(List.of("lc status link"))))
+      .andExpect(jsonPath(toLcStatusLink(workBase), equalTo(List.of("http://id/lc"))))
       .andExpect(jsonPath(toClassificationAssigningSourceIds(workBase), containsInAnyOrder("4932783899755316479",
         "8752404686183471966")))
       .andExpect(jsonPath(toClassificationAssigningSourceLabels(workBase), containsInAnyOrder("assigning agency",
@@ -1130,7 +1130,7 @@ abstract class ResourceControllerITBase extends ITBase {
     assertThat(status.getId()).isEqualTo(hashService.hash(status));
     assertThat(status.getDoc().size()).isEqualTo(2);
     assertThat(status.getDoc().get(LINK.getValue()).size()).isEqualTo(1);
-    assertThat(status.getDoc().get(LINK.getValue()).get(0).asText()).isEqualTo(prefix + " status link");
+    assertThat(status.getDoc().get(LINK.getValue()).get(0).asText()).isEqualTo("http://id/" + prefix);
     assertThat(status.getDoc().get(LABEL.getValue()).size()).isEqualTo(1);
     assertThat(status.getDoc().get(LABEL.getValue()).get(0).asText()).isEqualTo(prefix + " status value");
     assertThat(status.getOutgoingEdges()).isEmpty();

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnPatternValidationIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnPatternValidationIT.java
@@ -59,7 +59,7 @@ class ResourceControllerLccnPatternValidationIT extends ITBase {
       .headers(defaultHeaders(env))
       .content(INSTANCE_WITH_WORK_REF_SAMPLE
         .replaceAll(WORK_ID_PLACEHOLDER, work.getId().toString())
-        .replace("lccn status link", "http://id.loc.gov/vocabulary/mstatus/current")
+        .replace("http://id/lccn", "http://id.loc.gov/vocabulary/mstatus/current")
       );
     when(searchClient.searchInstances(any()))
       .thenReturn(new ResponseEntity<>(new SearchResponseTotalOnly().totalRecords(0L), HttpStatus.OK));

--- a/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnUniquenessValidationIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/resource/ResourceControllerLccnUniquenessValidationIT.java
@@ -58,7 +58,7 @@ class ResourceControllerLccnUniquenessValidationIT extends ITBase {
       .headers(defaultHeaders(env))
       .content(INSTANCE_WITH_WORK_REF_SAMPLE
         .replaceAll(WORK_ID_PLACEHOLDER, work.getId().toString())
-        .replace("lccn status link", "http://id.loc.gov/vocabulary/mstatus/current")
+        .replace("http://id/lccn", "http://id.loc.gov/vocabulary/mstatus/current")
         .replace("lccn value", "nn0123456789")
       );
     var query = "(lccn==\"nn0123456789\") and (staffSuppress <> \"true\" and discoverySuppress <> \"true\")";
@@ -125,7 +125,7 @@ class ResourceControllerLccnUniquenessValidationIT extends ITBase {
       .headers(defaultHeaders(env))
       .content(INSTANCE_WITH_WORK_REF_SAMPLE
         .replaceAll(WORK_ID_PLACEHOLDER, work.getId().toString())
-        .replace("lccn status link", "http://id.loc.gov/vocabulary/mstatus/current")
+        .replace("http://id/lccn", "http://id.loc.gov/vocabulary/mstatus/current")
         .replace("lccn value", "nn0123456789")
       );
     when(settingsService.isSettingEnabled(any(), any(), any())).thenReturn(false);
@@ -150,7 +150,7 @@ class ResourceControllerLccnUniquenessValidationIT extends ITBase {
       .headers(defaultHeaders(env))
       .content(INSTANCE_WITH_WORK_REF_SAMPLE
         .replaceAll(WORK_ID_PLACEHOLDER, work.getId().toString())
-        .replace("lccn status link", "http://id.loc.gov/vocabulary/mstatus/current")
+        .replace("http://id/lccn", "http://id.loc.gov/vocabulary/mstatus/current")
         .replace("lccn value", "nn0123456789")
       );
     var query = "(lccn==\"nn0123456789\") and (staffSuppress <> \"true\" and discoverySuppress <> \"true\")";

--- a/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
+++ b/src/test/java/org/folio/linked/data/test/MonographTestUtil.java
@@ -661,7 +661,7 @@ public class MonographTestUtil {
     return createResource(
       Map.of(
         LABEL, List.of(prefix + " status value"),
-        LINK, List.of(prefix + " status link")
+        LINK, List.of("http://id/" + prefix)
       ),
       Set.of(ResourceTypeDictionary.STATUS),
       emptyMap()

--- a/src/test/resources/samples/instance_and_work_ref.json
+++ b/src/test/resources/samples/instance_and_work_ref.json
@@ -186,7 +186,7 @@
                   "lccn status value"
                 ],
                 "http://bibfra.me/vocab/lite/link": [
-                  "lccn status link"
+                  "http://id/lccn"
                 ]
               }
             ]
@@ -206,7 +206,7 @@
                   "isbn status value"
                 ],
                 "http://bibfra.me/vocab/lite/link": [
-                  "isbn status link"
+                  "http://id/isbn"
                 ]
               }
             ]

--- a/src/test/resources/samples/work_and_instance_ref.json
+++ b/src/test/resources/samples/work_and_instance_ref.json
@@ -161,7 +161,7 @@
                 "lc status value"
               ],
               "http://bibfra.me/vocab/lite/link": [
-                "lc status link"
+                "http://id/lc"
               ]
             }
           ],


### PR DESCRIPTION
Recent changes to the lib-linked-data-rdf4ld library now expect a valid IRI for the status link value, update tests with contrived URIs.