### PR TITLE
MODLD-772: Insert new profiles for Work and Instance-Monograph into database

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - RDF Export: New API for getting RDF [MODLD-762](https://folio-org.atlassian.net/browse/MODLD-762)
 - Associate resource to profile [MODLD-746](https://folio-org.atlassian.net/browse/MODLD-746)
 - Remove unused API GET /linked-data/profile [MODLD-766](https://folio-org.atlassian.net/browse/MODLD-766)
+- Insert new profiles for Work and Instance-Monograph into database [MODLD-772](https://folio-org.atlassian.net/browse/MODLD-772)
 
 ## 1.0.4 (04-24-2025)
 - Work Edit form - Instance read-only section: "Notes about the instance" data is not shown [MODLD-716](https://folio-org.atlassian.net/browse/MODLD-716)

--- a/src/main/resources/profiles/instance-monograph.json
+++ b/src/main/resources/profiles/instance-monograph.json
@@ -1,948 +1,8 @@
 {
-  "id": 1,
-  "name": "Monograph - To be deleted",
+  "id": 3,
+  "name": "Monograph",
   "resourceType": "http://bibfra.me/vocab/lite/Instance",
   "value": [
-    {
-      "type": "profile",
-      "displayName": "Monograph",
-      "bfid": "monograph",
-      "children": ["Monograph:Work", "Monograph:Instance"],
-      "id": "Monograph"
-    },
-    {
-      "type": "block",
-      "displayName": "Work",
-      "bfid": "lc:RT:bf2:Monograph:Work",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Work",
-      "children": [
-        "Monograph:Work:CreatorOfWork",
-        "Monograph:Work:TitleInformation",
-        "Monograph:Work:GovernmentPublication",
-        "Monograph:Work:DateOfWork",
-        "Monograph:Work:PlaceOfOriginOfTheWork",
-        "Monograph:Work:GeographicCoverage",
-        "Monograph:Work:IntendedAudience",
-        "Monograph:Work:OtherContributors",
-        "Monograph:Work:NotesAboutTheWork",
-        "Monograph:Work:ContentsNote",
-        "Monograph:Work:SummaryNote",
-        "Monograph:Work:SubjectOfTheWork",
-        "Monograph:Work:ClassificationNumbers",
-        "Monograph:Work:ContentType",
-        "Monograph:Work:LanguageCode"
-      ],
-      "id": "Monograph:Work"
-    },
-    {
-      "type": "group",
-      "displayName": "Creator of Work",
-      "uriBFLite": "_creatorReference",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution" }
-      },
-      "children": [
-        "Monograph:Work:CreatorOfWork:Name",
-        "Monograph:Work:CreatorOfWork:Subclass",
-        "Monograph:Work:CreatorOfWork:Relationship"
-      ],
-      "id": "Monograph:Work:CreatorOfWork"
-    },
-    {
-      "bfid": "lc:RT:bf2:search:name",
-      "type": "complex",
-      "displayName": "Name",
-      "uriBFLite": "_name",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://preprod.id.loc.gov/authorities/names"],
-        "valueDataType": {}
-      },
-      "layout": { "api": "authorities", "isNew": true, "baseLabelType": "creator" },
-      "linkedEntry": { "dependent": "Monograph:Work:CreatorOfWork:Subclass" },
-      "id": "Monograph:Work:CreatorOfWork:Name"
-    },
-    {
-      "type": "dropdown",
-      "displayName": "Subclass",
-      "uriBFLite": "_subclass",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution" }
-      },
-      "children": [
-        "Monograph:Work:CreatorOfWork:Subclass:Person",
-        "Monograph:Work:CreatorOfWork:Subclass:Family",
-        "Monograph:Work:CreatorOfWork:Subclass:CorporateBody",
-        "Monograph:Work:CreatorOfWork:Subclass:Jurisdiction",
-        "Monograph:Work:CreatorOfWork:Subclass:Conference"
-      ],
-      "layout": { "readOnly": true },
-      "dependsOn": "lc:RT:bf2:search:name",
-      "linkedEntry": { "controlledBy": "Monograph:Work:CreatorOfWork:Name" },
-      "id": "Monograph:Work:CreatorOfWork:Subclass"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Person",
-      "bfid": "lc:RT:bf2:Agent:bfPerson:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Person",
-      "children": [],
-      "id": "Monograph:Work:CreatorOfWork:Subclass:Person"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Family",
-      "bfid": "lc:RT:bf2:Agent:bfFamily:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Family",
-      "children": [],
-      "id": "Monograph:Work:CreatorOfWork:Subclass:Family"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Corporate Body",
-      "bfid": "lc:RT:bf2:Agent:bfCorp:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Organization",
-      "children": [],
-      "id": "Monograph:Work:CreatorOfWork:Subclass:CorporateBody"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Jurisdiction",
-      "bfid": "lc:RT:bf2:Agent:bfJurisdiction:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Jurisdiction",
-      "children": [],
-      "id": "Monograph:Work:CreatorOfWork:Subclass:Jurisdiction"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Conference",
-      "bfid": "lc:RT:bf2:Agent:bfConf:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Meeting",
-      "children": [],
-      "id": "Monograph:Work:CreatorOfWork:Subclass:Conference"
-    },
-    {
-      "type": "simple",
-      "displayName": "Relationship",
-      "uriBFLite": "roles",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/relators", "https://id.loc.gov/vocabulary/rbmsrel"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Role" }
-      },
-      "id": "Monograph:Work:CreatorOfWork:Relationship"
-    },
-    {
-      "type": "dropdown",
-      "displayName": "Title Information",
-      "uriBFLite": "http://bibfra.me/vocab/marc/title",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "children": [
-        "Monograph:Work:TitleInformation:WorkTitle",
-        "Monograph:Work:TitleInformation:VariantTitle",
-        "Monograph:Work:TitleInformation:ParallelTitle"
-      ],
-      "id": "Monograph:Work:TitleInformation"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Work Title",
-      "bfid": "lc:RT:bf2:WorkTitle",
-      "uriBFLite": "http://bibfra.me/vocab/marc/Title",
-      "children": [
-        "Monograph:Work:TitleInformation:WorkTitle:NonSortCharacterCount",
-        "Monograph:Work:TitleInformation:WorkTitle:PreferredTitleForWork",
-        "Monograph:Work:TitleInformation:WorkTitle:PartNumber",
-        "Monograph:Work:TitleInformation:WorkTitle:PartName"
-      ],
-      "id": "Monograph:Work:TitleInformation:WorkTitle"
-    },
-    {
-      "type": "literal",
-      "displayName": "Non-sort character count",
-      "uriBFLite": "http://bibfra.me/vocab/bflc/nonSortNum",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:WorkTitle:NonSortCharacterCount"
-    },
-    {
-      "type": "literal",
-      "displayName": "Preferred Title for Work",
-      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": { "dataTypeURI": "" }
-      },
-      "id": "Monograph:Work:TitleInformation:WorkTitle:PreferredTitleForWork"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:WorkTitle:PartNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part name",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:WorkTitle:PartName"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Variant Title",
-      "bfid": "lc:RT:bf2:Title:VarTitle",
-      "uriBFLite": "http://bibfra.me/vocab/marc/VariantTitle",
-      "children": [
-        "Monograph:Work:TitleInformation:VariantTitle:VariantTitle",
-        "Monograph:Work:TitleInformation:VariantTitle:PartNumber",
-        "Monograph:Work:TitleInformation:VariantTitle:PartName",
-        "Monograph:Work:TitleInformation:VariantTitle:OtherTitleInformation",
-        "Monograph:Work:TitleInformation:VariantTitle:Date",
-        "Monograph:Work:TitleInformation:VariantTitle:VariantTitleType",
-        "Monograph:Work:TitleInformation:VariantTitle:Note"
-      ],
-      "id": "Monograph:Work:TitleInformation:VariantTitle"
-    },
-    {
-      "type": "literal",
-      "displayName": "Variant Title",
-      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:VariantTitle"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:PartNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part name",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:PartName"
-    },
-    {
-      "type": "literal",
-      "displayName": "Other title information",
-      "uriBFLite": "http://bibfra.me/vocab/marc/subTitle",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:OtherTitleInformation"
-    },
-    {
-      "type": "literal",
-      "displayName": "Date",
-      "uriBFLite": "http://bibfra.me/vocab/lite/date",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:Date"
-    },
-    {
-      "type": "literal",
-      "displayName": "Variant title type",
-      "uriBFLite": "http://bibfra.me/vocab/marc/variantType",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:VariantTitleType"
-    },
-    {
-      "type": "literal",
-      "displayName": "Note",
-      "uriBFLite": "http://bibfra.me/vocab/lite/note",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:VariantTitle:Note"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Parallel Title",
-      "bfid": "lc:RT:bf2:ParallelTitle",
-      "uriBFLite": "http://bibfra.me/vocab/marc/ParallelTitle",
-      "children": [
-        "Monograph:Work:TitleInformation:ParallelTitle:ParallelTitle",
-        "Monograph:Work:TitleInformation:ParallelTitle:OtherTitleInformation",
-        "Monograph:Work:TitleInformation:ParallelTitle:PartNumber",
-        "Monograph:Work:TitleInformation:ParallelTitle:PartName",
-        "Monograph:Work:TitleInformation:ParallelTitle:Date",
-        "Monograph:Work:TitleInformation:ParallelTitle:Note"
-      ],
-      "id": "Monograph:Work:TitleInformation:ParallelTitle"
-    },
-    {
-      "type": "literal",
-      "displayName": "Parallel Title",
-      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:ParallelTitle"
-    },
-    {
-      "type": "literal",
-      "displayName": "Other Title Information",
-      "uriBFLite": "http://bibfra.me/vocab/marc/subTitle",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:OtherTitleInformation"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:PartNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Part name",
-      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:PartName"
-    },
-    {
-      "type": "literal",
-      "displayName": "Date",
-      "uriBFLite": "http://bibfra.me/vocab/lite/date",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:Date"
-    },
-    {
-      "type": "literal",
-      "displayName": "Note",
-      "uriBFLite": "http://bibfra.me/vocab/lite/note",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:TitleInformation:ParallelTitle:Note"
-    },
-    {
-      "type": "simple",
-      "displayName": "Government publication",
-      "uriBFLite": "http://bibfra.me/vocab/marc/governmentPublication",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/mgovtpubtype"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bflc/GovernmentPubType" }
-      },
-      "id": "Monograph:Work:GovernmentPublication"
-    },
-    {
-      "type": "literal",
-      "displayName": "Date of Work",
-      "uriBFLite": "http://bibfra.me/vocab/lite/dateStart",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:DateOfWork"
-    },
-    {
-      "type": "simple",
-      "displayName": "Place of Origin of the Work",
-      "uriBFLite": "http://bibfra.me/vocab/marc/originPlace",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place" }
-      },
-      "id": "Monograph:Work:PlaceOfOriginOfTheWork"
-    },
-    {
-      "type": "group",
-      "displayName": "Geographic Coverage",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "children": ["Monograph:Work:GeographicCoverage:SearchLCNAFLCSHOrGAC"],
-      "id": "Monograph:Work:GeographicCoverage"
-    },
-    {
-      "type": "complex",
-      "displayName": "Search LCNAF, LCSH or GAC",
-      "uriBFLite": "_geographicCoverageReference",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/authorities/geographics"],
-        "valueDataType": { "remark": "", "dataTypeURI": "" }
-      },
-      "id": "Monograph:Work:GeographicCoverage:SearchLCNAFLCSHOrGAC"
-    },
-    {
-      "type": "simple",
-      "displayName": "Intended Audience",
-      "uriBFLite": "http://bibfra.me/vocab/marc/targetAudience",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/maudience"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience" }
-      },
-      "id": "Monograph:Work:IntendedAudience"
-    },
-    {
-      "type": "group",
-      "displayName": "Other contributors",
-      "uriBFLite": "_contributorReference",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution" }
-      },
-      "children": [
-        "Monograph:Work:OtherContributors:Name",
-        "Monograph:Work:OtherContributors:Subclass",
-        "Monograph:Work:OtherContributors:Relationship"
-      ],
-      "id": "Monograph:Work:OtherContributors"
-    },
-    {
-      "bfid": "lc:RT:bf2:search:name",
-      "type": "complex",
-      "displayName": "Name",
-      "uriBFLite": "_name",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://preprod.id.loc.gov/authorities/names"],
-        "valueDataType": {}
-      },
-      "layout": { "api": "authorities", "isNew": true, "baseLabelType": "contributor" },
-      "linkedEntry": { "dependent": "Monograph:Work:OtherContributors:Subclass" },
-      "id": "Monograph:Work:OtherContributors:Name"
-    },
-    {
-      "type": "dropdown",
-      "displayName": "Subclass",
-      "uriBFLite": "_subclass",
-      "constraints": { "repeatable": true, "editable": true, "mandatory": true, "defaults": [], "useValuesFrom": [] },
-      "children": [
-        "Monograph:Work:OtherContributors:Subclass:Person",
-        "Monograph:Work:OtherContributors:Subclass:Family",
-        "Monograph:Work:OtherContributors:Subclass:CorporateBody",
-        "Monograph:Work:OtherContributors:Subclass:Jurisdiction",
-        "Monograph:Work:OtherContributors:Subclass:Conference"
-      ],
-      "layout": { "readOnly": true },
-      "dependsOn": "lc:RT:bf2:search:name",
-      "linkedEntry": { "controlledBy": "Monograph:Work:OtherContributors:Name" },
-      "id": "Monograph:Work:OtherContributors:Subclass"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Person",
-      "bfid": "lc:RT:bf2:Agent:bfPerson:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Person",
-      "children": [],
-      "id": "Monograph:Work:OtherContributors:Subclass:Person"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Family",
-      "bfid": "lc:RT:bf2:Agent:bfFamily:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Family",
-      "children": [],
-      "id": "Monograph:Work:OtherContributors:Subclass:Family"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Corporate Body",
-      "bfid": "lc:RT:bf2:Agent:bfCorp:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Organization",
-      "children": [],
-      "id": "Monograph:Work:OtherContributors:Subclass:CorporateBody"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Jurisdiction",
-      "bfid": "lc:RT:bf2:Agent:bfJurisdiction:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Jurisdiction",
-      "children": [],
-      "id": "Monograph:Work:OtherContributors:Subclass:Jurisdiction"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Conference",
-      "bfid": "lc:RT:bf2:Agent:bfConf:v2",
-      "uriBFLite": "http://bibfra.me/vocab/lite/Meeting",
-      "children": [],
-      "id": "Monograph:Work:OtherContributors:Subclass:Conference"
-    },
-    {
-      "type": "simple",
-      "displayName": "Relationship",
-      "uriBFLite": "roles",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/relators", "https://id.loc.gov/vocabulary/rbmsrel"]
-      },
-      "id": "Monograph:Work:OtherContributors:Relationship"
-    },
-    {
-      "type": "group",
-      "displayName": "Notes about the Work",
-      "uriBFLite": "_notes",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "children": ["Monograph:Work:NotesAboutTheWork:Note", "Monograph:Work:NotesAboutTheWork:NoteType"],
-      "id": "Monograph:Work:NotesAboutTheWork"
-    },
-    {
-      "type": "literal",
-      "displayName": "Note",
-      "uriBFLite": "value",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:NotesAboutTheWork:Note"
-    },
-    {
-      "type": "simple",
-      "displayName": "Note type",
-      "uriBFLite": "type",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/mnotetype"],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:NotesAboutTheWork:NoteType"
-    },
-    {
-      "type": "literal",
-      "groupName": "Contents",
-      "displayName": "Contents note",
-      "uriBFLite": "http://bibfra.me/vocab/marc/tableOfContents",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ContentsNote"
-    },
-    {
-      "type": "literal",
-      "displayName": "Summary note",
-      "uriBFLite": "http://bibfra.me/vocab/marc/summary",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:SummaryNote"
-    },
-    {
-      "type": "group",
-      "displayName": "Subject of the Work",
-      "uriBFLite": "http://bibfra.me/vocab/lite/subject",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "children": ["Monograph:Work:SubjectOfTheWork:SearchLCSHLCNAF"],
-      "id": "Monograph:Work:SubjectOfTheWork"
-    },
-    {
-      "type": "complex",
-      "displayName": "Search LCSH/LCNAF",
-      "uriBFLite": "label",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/authorities/subjects", "http://preprod.id.loc.gov/authorities/names"],
-        "valueDataType": { "dataTypeURI": "" }
-      },
-      "layout": { "api": "authoritiesSubject", "isNew": true, "baseLabelType": "subject" },
-      "id": "Monograph:Work:SubjectOfTheWork:SearchLCSHLCNAF"
-    },
-    {
-      "type": "dropdown",
-      "displayName": "Classification numbers",
-      "uriBFLite": "http://bibfra.me/vocab/lite/classification",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "children": [
-        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification",
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification"
-      ],
-      "deletable": true,
-      "cloneIndex": 0,
-      "id": "Monograph:Work:ClassificationNumbers"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Library of Congress Classification",
-      "bfid": "lc:RT:bf2:LCC",
-      "uriBFLite": "lc",
-      "children": [
-        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:ClassificationNumber",
-        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AdditionalCallNumberInformation",
-        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AssigningAgency",
-        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:UsedByAssigningAgency"
-      ],
-      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification"
-    },
-    {
-      "type": "literal",
-      "displayName": "Classification number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/code",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:ClassificationNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Additional call number information",
-      "uriBFLite": "http://bibfra.me/vocab/marc/itemNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AdditionalCallNumberInformation"
-    },
-    {
-      "type": "complex",
-      "displayName": "Assigning agency",
-      "uriBFLite": "_assigningSourceReference",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/organizations"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent" }
-      },
-      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AssigningAgency"
-    },
-    {
-      "type": "simple",
-      "displayName": "Used by assigning agency?",
-      "uriBFLite": "http://bibfra.me/vocab/marc/status",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/mstatus"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status" }
-      },
-      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:UsedByAssigningAgency"
-    },
-    {
-      "type": "dropdownOption",
-      "displayName": "Dewey Decimal Classification",
-      "bfid": "lc:RT:bf2:DDC",
-      "uriBFLite": "ddc",
-      "children": [
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:ClassificationNumber",
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:AdditionalCallNumberInformation",
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyEditionNumber",
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyFullOrAbridged",
-        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:Assigner"
-      ],
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification"
-    },
-    {
-      "type": "literal",
-      "displayName": "Classification number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/code",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:ClassificationNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Additional call number information",
-      "uriBFLite": "http://bibfra.me/vocab/marc/itemNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:AdditionalCallNumberInformation"
-    },
-    {
-      "type": "literal",
-      "displayName": "Dewey Edition number",
-      "uriBFLite": "http://bibfra.me/vocab/marc/editionNumber",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyEditionNumber"
-    },
-    {
-      "type": "literal",
-      "displayName": "Dewey full or abridged?",
-      "uriBFLite": "http://bibfra.me/vocab/marc/edition",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": [],
-        "valueDataType": {}
-      },
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyFullOrAbridged"
-    },
-    {
-      "type": "complex",
-      "displayName": "Assigner",
-      "uriBFLite": "_assigningSourceReference",
-      "constraints": {
-        "repeatable": true,
-        "editable": false,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/organizations"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent" }
-      },
-      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:Assigner"
-    },
-    {
-      "type": "simple",
-      "displayName": "Content Type",
-      "uriBFLite": "http://bibfra.me/vocab/marc/content",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/contentTypes"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content" }
-      },
-      "id": "Monograph:Work:ContentType"
-    },
-    {
-      "type": "simple",
-      "groupName": "Language",
-      "displayName": "Language code",
-      "uriBFLite": "http://bibfra.me/vocab/lite/language",
-      "constraints": {
-        "repeatable": true,
-        "editable": true,
-        "mandatory": true,
-        "defaults": [],
-        "useValuesFrom": ["http://id.loc.gov/vocabulary/languages"],
-        "valueDataType": { "remark": "", "dataTypeURI": "" }
-      },
-      "id": "Monograph:Work:LanguageCode"
-    },
     {
       "type": "block",
       "displayName": "Instance",
@@ -1368,7 +428,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+        }
       },
       "id": "Monograph:Instance:ProvisionActivity:Publication:SearchPlaceOfPublicationToFrom008"
     },
@@ -1452,7 +514,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+        }
       },
       "id": "Monograph:Instance:ProvisionActivity:Distribution:SearchPlaceOfPublicationToFrom008"
     },
@@ -1536,7 +600,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+        }
       },
       "id": "Monograph:Instance:ProvisionActivity:Manufacture:SearchPlaceOfPublicationToFrom008"
     },
@@ -1620,7 +686,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+        }
       },
       "id": "Monograph:Instance:ProvisionActivity:Production:SearchPlaceOfPublicationToFrom008"
     },
@@ -1690,7 +758,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/issuance"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Issuance"
+        }
       },
       "id": "Monograph:Instance:ModeOfIssuance"
     },
@@ -1706,7 +776,10 @@
         "useValuesFrom": [],
         "valueDataType": {}
       },
-      "children": ["Monograph:Instance:Identifiers:LCCN", "Monograph:Instance:Identifiers:ISBN"],
+      "children": [
+        "Monograph:Instance:Identifiers:LCCN",
+        "Monograph:Instance:Identifiers:ISBN"
+      ],
       "id": "Monograph:Instance:Identifiers"
     },
     {
@@ -1714,7 +787,10 @@
       "displayName": "LCCN",
       "bfid": "lc:RT:bf2:Identifiers:LCCN",
       "uriBFLite": "http://library.link/identifier/LCCN",
-      "children": ["Monograph:Instance:Identifiers:LCCN:LCCN", "Monograph:Instance:Identifiers:LCCN:InvalidCanceled"],
+      "children": [
+        "Monograph:Instance:Identifiers:LCCN:LCCN",
+        "Monograph:Instance:Identifiers:LCCN:InvalidCanceled"
+      ],
       "id": "Monograph:Instance:Identifiers:LCCN"
     },
     {
@@ -1741,7 +817,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/mstatus"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
       },
       "id": "Monograph:Instance:Identifiers:LCCN:InvalidCanceled"
     },
@@ -1795,7 +873,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/mstatus"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
       },
       "id": "Monograph:Instance:Identifiers:ISBN:IncorrectInvalidOrCanceled"
     },
@@ -1811,7 +891,10 @@
         "useValuesFrom": [],
         "valueDataType": {}
       },
-      "children": ["Monograph:Instance:NotesAboutTheInstance:Note", "Monograph:Instance:NotesAboutTheInstance:NoteType"],
+      "children": [
+        "Monograph:Instance:NotesAboutTheInstance:Note",
+        "Monograph:Instance:NotesAboutTheInstance:NoteType"
+      ],
       "id": "Monograph:Instance:NotesAboutTheInstance"
     },
     {
@@ -1898,7 +981,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/mediaTypes"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Media"
+        }
       },
       "id": "Monograph:Instance:MediaType"
     },
@@ -1941,7 +1026,9 @@
         "mandatory": true,
         "defaults": [],
         "useValuesFrom": ["http://id.loc.gov/vocabulary/carriers"],
-        "valueDataType": { "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier" }
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Carrier"
+        }
       },
       "id": "Monograph:Instance:CarrierType"
     },
@@ -1957,7 +1044,10 @@
         "useValuesFrom": [],
         "valueDataType": {}
       },
-      "children": ["Monograph:Instance:URLOfInstance:URL", "Monograph:Instance:URLOfInstance:Note"],
+      "children": [
+        "Monograph:Instance:URLOfInstance:URL",
+        "Monograph:Instance:URLOfInstance:Note"
+      ],
       "id": "Monograph:Instance:URLOfInstance"
     },
     {

--- a/src/main/resources/profiles/work.json
+++ b/src/main/resources/profiles/work.json
@@ -1,0 +1,992 @@
+{
+  "id": 2,
+  "name": "Work",
+  "resourceType": "http://bibfra.me/vocab/lite/Work",
+  "value": [
+    {
+      "type": "block",
+      "displayName": "Work",
+      "bfid": "lc:RT:bf2:Monograph:Work",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Work",
+      "children": [
+        "Monograph:Work:CreatorOfWork",
+        "Monograph:Work:TitleInformation",
+        "Monograph:Work:GovernmentPublication",
+        "Monograph:Work:DateOfWork",
+        "Monograph:Work:PlaceOfOriginOfTheWork",
+        "Monograph:Work:GeographicCoverage",
+        "Monograph:Work:IntendedAudience",
+        "Monograph:Work:OtherContributors",
+        "Monograph:Work:NotesAboutTheWork",
+        "Monograph:Work:ContentsNote",
+        "Monograph:Work:SummaryNote",
+        "Monograph:Work:SubjectOfTheWork",
+        "Monograph:Work:ClassificationNumbers",
+        "Monograph:Work:ContentType",
+        "Monograph:Work:LanguageCode"
+      ],
+      "id": "Monograph:Work"
+    },
+    {
+      "type": "group",
+      "displayName": "Creator of Work",
+      "uriBFLite": "_creatorReference",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+        }
+      },
+      "children": [
+        "Monograph:Work:CreatorOfWork:Name",
+        "Monograph:Work:CreatorOfWork:Subclass",
+        "Monograph:Work:CreatorOfWork:Relationship"
+      ],
+      "id": "Monograph:Work:CreatorOfWork"
+    },
+    {
+      "bfid": "lc:RT:bf2:search:name",
+      "type": "complex",
+      "displayName": "Name",
+      "uriBFLite": "_name",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://preprod.id.loc.gov/authorities/names"],
+        "valueDataType": {}
+      },
+      "layout": {
+        "api": "authorities",
+        "isNew": true,
+        "baseLabelType": "creator"
+      },
+      "linkedEntry": { "dependent": "Monograph:Work:CreatorOfWork:Subclass" },
+      "id": "Monograph:Work:CreatorOfWork:Name"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Subclass",
+      "uriBFLite": "_subclass",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bflc/PrimaryContribution"
+        }
+      },
+      "children": [
+        "Monograph:Work:CreatorOfWork:Subclass:Person",
+        "Monograph:Work:CreatorOfWork:Subclass:Family",
+        "Monograph:Work:CreatorOfWork:Subclass:CorporateBody",
+        "Monograph:Work:CreatorOfWork:Subclass:Jurisdiction",
+        "Monograph:Work:CreatorOfWork:Subclass:Conference"
+      ],
+      "layout": { "readOnly": true },
+      "dependsOn": "lc:RT:bf2:search:name",
+      "linkedEntry": { "controlledBy": "Monograph:Work:CreatorOfWork:Name" },
+      "id": "Monograph:Work:CreatorOfWork:Subclass"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Person",
+      "bfid": "lc:RT:bf2:Agent:bfPerson:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Person",
+      "children": [],
+      "id": "Monograph:Work:CreatorOfWork:Subclass:Person"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Family",
+      "bfid": "lc:RT:bf2:Agent:bfFamily:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Family",
+      "children": [],
+      "id": "Monograph:Work:CreatorOfWork:Subclass:Family"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Corporate Body",
+      "bfid": "lc:RT:bf2:Agent:bfCorp:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Organization",
+      "children": [],
+      "id": "Monograph:Work:CreatorOfWork:Subclass:CorporateBody"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Jurisdiction",
+      "bfid": "lc:RT:bf2:Agent:bfJurisdiction:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Jurisdiction",
+      "children": [],
+      "id": "Monograph:Work:CreatorOfWork:Subclass:Jurisdiction"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Conference",
+      "bfid": "lc:RT:bf2:Agent:bfConf:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Meeting",
+      "children": [],
+      "id": "Monograph:Work:CreatorOfWork:Subclass:Conference"
+    },
+    {
+      "type": "simple",
+      "displayName": "Relationship",
+      "uriBFLite": "roles",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/relators",
+          "https://id.loc.gov/vocabulary/rbmsrel"
+        ],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Role"
+        }
+      },
+      "id": "Monograph:Work:CreatorOfWork:Relationship"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Title Information",
+      "uriBFLite": "http://bibfra.me/vocab/marc/title",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": [
+        "Monograph:Work:TitleInformation:WorkTitle",
+        "Monograph:Work:TitleInformation:VariantTitle",
+        "Monograph:Work:TitleInformation:ParallelTitle"
+      ],
+      "id": "Monograph:Work:TitleInformation"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Work Title",
+      "bfid": "lc:RT:bf2:WorkTitle",
+      "uriBFLite": "http://bibfra.me/vocab/marc/Title",
+      "children": [
+        "Monograph:Work:TitleInformation:WorkTitle:NonSortCharacterCount",
+        "Monograph:Work:TitleInformation:WorkTitle:PreferredTitleForWork",
+        "Monograph:Work:TitleInformation:WorkTitle:PartNumber",
+        "Monograph:Work:TitleInformation:WorkTitle:PartName"
+      ],
+      "id": "Monograph:Work:TitleInformation:WorkTitle"
+    },
+    {
+      "type": "literal",
+      "displayName": "Non-sort character count",
+      "uriBFLite": "http://bibfra.me/vocab/bflc/nonSortNum",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:WorkTitle:NonSortCharacterCount"
+    },
+    {
+      "type": "literal",
+      "displayName": "Preferred Title for Work",
+      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": { "dataTypeURI": "" }
+      },
+      "id": "Monograph:Work:TitleInformation:WorkTitle:PreferredTitleForWork"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:WorkTitle:PartNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part name",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:WorkTitle:PartName"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Variant Title",
+      "bfid": "lc:RT:bf2:Title:VarTitle",
+      "uriBFLite": "http://bibfra.me/vocab/marc/VariantTitle",
+      "children": [
+        "Monograph:Work:TitleInformation:VariantTitle:VariantTitle",
+        "Monograph:Work:TitleInformation:VariantTitle:PartNumber",
+        "Monograph:Work:TitleInformation:VariantTitle:PartName",
+        "Monograph:Work:TitleInformation:VariantTitle:OtherTitleInformation",
+        "Monograph:Work:TitleInformation:VariantTitle:Date",
+        "Monograph:Work:TitleInformation:VariantTitle:VariantTitleType",
+        "Monograph:Work:TitleInformation:VariantTitle:Note"
+      ],
+      "id": "Monograph:Work:TitleInformation:VariantTitle"
+    },
+    {
+      "type": "literal",
+      "displayName": "Variant Title",
+      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:VariantTitle"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:PartNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part name",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:PartName"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other title information",
+      "uriBFLite": "http://bibfra.me/vocab/marc/subTitle",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:OtherTitleInformation"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:Date"
+    },
+    {
+      "type": "literal",
+      "displayName": "Variant title type",
+      "uriBFLite": "http://bibfra.me/vocab/marc/variantType",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:VariantTitleType"
+    },
+    {
+      "type": "literal",
+      "displayName": "Note",
+      "uriBFLite": "http://bibfra.me/vocab/lite/note",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:VariantTitle:Note"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Parallel Title",
+      "bfid": "lc:RT:bf2:ParallelTitle",
+      "uriBFLite": "http://bibfra.me/vocab/marc/ParallelTitle",
+      "children": [
+        "Monograph:Work:TitleInformation:ParallelTitle:ParallelTitle",
+        "Monograph:Work:TitleInformation:ParallelTitle:OtherTitleInformation",
+        "Monograph:Work:TitleInformation:ParallelTitle:PartNumber",
+        "Monograph:Work:TitleInformation:ParallelTitle:PartName",
+        "Monograph:Work:TitleInformation:ParallelTitle:Date",
+        "Monograph:Work:TitleInformation:ParallelTitle:Note"
+      ],
+      "id": "Monograph:Work:TitleInformation:ParallelTitle"
+    },
+    {
+      "type": "literal",
+      "displayName": "Parallel Title",
+      "uriBFLite": "http://bibfra.me/vocab/marc/mainTitle",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:ParallelTitle"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Title Information",
+      "uriBFLite": "http://bibfra.me/vocab/marc/subTitle",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:OtherTitleInformation"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:PartNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Part name",
+      "uriBFLite": "http://bibfra.me/vocab/marc/partName",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:PartName"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:Date"
+    },
+    {
+      "type": "literal",
+      "displayName": "Note",
+      "uriBFLite": "http://bibfra.me/vocab/lite/note",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:TitleInformation:ParallelTitle:Note"
+    },
+    {
+      "type": "simple",
+      "displayName": "Government publication",
+      "uriBFLite": "http://bibfra.me/vocab/marc/governmentPublication",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/mgovtpubtype"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bflc/GovernmentPubType"
+        }
+      },
+      "id": "Monograph:Work:GovernmentPublication"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date of Work",
+      "uriBFLite": "http://bibfra.me/vocab/lite/dateStart",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:DateOfWork"
+    },
+    {
+      "type": "simple",
+      "displayName": "Place of Origin of the Work",
+      "uriBFLite": "http://bibfra.me/vocab/marc/originPlace",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/countries"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Place"
+        }
+      },
+      "id": "Monograph:Work:PlaceOfOriginOfTheWork"
+    },
+    {
+      "type": "group",
+      "displayName": "Geographic Coverage",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Monograph:Work:GeographicCoverage:SearchLCNAFLCSHOrGAC"],
+      "id": "Monograph:Work:GeographicCoverage"
+    },
+    {
+      "type": "complex",
+      "displayName": "Search LCNAF, LCSH or GAC",
+      "uriBFLite": "_geographicCoverageReference",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/authorities/geographics"],
+        "valueDataType": { "remark": "", "dataTypeURI": "" }
+      },
+      "id": "Monograph:Work:GeographicCoverage:SearchLCNAFLCSHOrGAC"
+    },
+    {
+      "type": "simple",
+      "displayName": "Intended Audience",
+      "uriBFLite": "http://bibfra.me/vocab/marc/targetAudience",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/maudience"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/IntendedAudience"
+        }
+      },
+      "id": "Monograph:Work:IntendedAudience"
+    },
+    {
+      "type": "group",
+      "displayName": "Other contributors",
+      "uriBFLite": "_contributorReference",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Contribution"
+        }
+      },
+      "children": [
+        "Monograph:Work:OtherContributors:Name",
+        "Monograph:Work:OtherContributors:Subclass",
+        "Monograph:Work:OtherContributors:Relationship"
+      ],
+      "id": "Monograph:Work:OtherContributors"
+    },
+    {
+      "bfid": "lc:RT:bf2:search:name",
+      "type": "complex",
+      "displayName": "Name",
+      "uriBFLite": "_name",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://preprod.id.loc.gov/authorities/names"],
+        "valueDataType": {}
+      },
+      "layout": {
+        "api": "authorities",
+        "isNew": true,
+        "baseLabelType": "contributor"
+      },
+      "linkedEntry": { "dependent": "Monograph:Work:OtherContributors:Subclass" },
+      "id": "Monograph:Work:OtherContributors:Name"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Subclass",
+      "uriBFLite": "_subclass",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": []
+      },
+      "children": [
+        "Monograph:Work:OtherContributors:Subclass:Person",
+        "Monograph:Work:OtherContributors:Subclass:Family",
+        "Monograph:Work:OtherContributors:Subclass:CorporateBody",
+        "Monograph:Work:OtherContributors:Subclass:Jurisdiction",
+        "Monograph:Work:OtherContributors:Subclass:Conference"
+      ],
+      "layout": { "readOnly": true },
+      "dependsOn": "lc:RT:bf2:search:name",
+      "linkedEntry": { "controlledBy": "Monograph:Work:OtherContributors:Name" },
+      "id": "Monograph:Work:OtherContributors:Subclass"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Person",
+      "bfid": "lc:RT:bf2:Agent:bfPerson:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Person",
+      "children": [],
+      "id": "Monograph:Work:OtherContributors:Subclass:Person"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Family",
+      "bfid": "lc:RT:bf2:Agent:bfFamily:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Family",
+      "children": [],
+      "id": "Monograph:Work:OtherContributors:Subclass:Family"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Corporate Body",
+      "bfid": "lc:RT:bf2:Agent:bfCorp:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Organization",
+      "children": [],
+      "id": "Monograph:Work:OtherContributors:Subclass:CorporateBody"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Jurisdiction",
+      "bfid": "lc:RT:bf2:Agent:bfJurisdiction:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Jurisdiction",
+      "children": [],
+      "id": "Monograph:Work:OtherContributors:Subclass:Jurisdiction"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Conference",
+      "bfid": "lc:RT:bf2:Agent:bfConf:v2",
+      "uriBFLite": "http://bibfra.me/vocab/lite/Meeting",
+      "children": [],
+      "id": "Monograph:Work:OtherContributors:Subclass:Conference"
+    },
+    {
+      "type": "simple",
+      "displayName": "Relationship",
+      "uriBFLite": "roles",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/vocabulary/relators",
+          "https://id.loc.gov/vocabulary/rbmsrel"
+        ]
+      },
+      "id": "Monograph:Work:OtherContributors:Relationship"
+    },
+    {
+      "type": "group",
+      "displayName": "Notes about the Work",
+      "uriBFLite": "_notes",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": [
+        "Monograph:Work:NotesAboutTheWork:Note",
+        "Monograph:Work:NotesAboutTheWork:NoteType"
+      ],
+      "id": "Monograph:Work:NotesAboutTheWork"
+    },
+    {
+      "type": "literal",
+      "displayName": "Note",
+      "uriBFLite": "value",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:NotesAboutTheWork:Note"
+    },
+    {
+      "type": "simple",
+      "displayName": "Note type",
+      "uriBFLite": "type",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/mnotetype"],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:NotesAboutTheWork:NoteType"
+    },
+    {
+      "type": "literal",
+      "groupName": "Contents",
+      "displayName": "Contents note",
+      "uriBFLite": "http://bibfra.me/vocab/marc/tableOfContents",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ContentsNote"
+    },
+    {
+      "type": "literal",
+      "displayName": "Summary note",
+      "uriBFLite": "http://bibfra.me/vocab/marc/summary",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:SummaryNote"
+    },
+    {
+      "type": "group",
+      "displayName": "Subject of the Work",
+      "uriBFLite": "http://bibfra.me/vocab/lite/subject",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Monograph:Work:SubjectOfTheWork:SearchLCSHLCNAF"],
+      "id": "Monograph:Work:SubjectOfTheWork"
+    },
+    {
+      "type": "complex",
+      "displayName": "Search LCSH/LCNAF",
+      "uriBFLite": "label",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [
+          "http://id.loc.gov/authorities/subjects",
+          "http://preprod.id.loc.gov/authorities/names"
+        ],
+        "valueDataType": { "dataTypeURI": "" }
+      },
+      "layout": {
+        "api": "authoritiesSubject",
+        "isNew": true,
+        "baseLabelType": "subject"
+      },
+      "id": "Monograph:Work:SubjectOfTheWork:SearchLCSHLCNAF"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Classification numbers",
+      "uriBFLite": "http://bibfra.me/vocab/lite/classification",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": [
+        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification",
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification"
+      ],
+      "deletable": true,
+      "cloneIndex": 0,
+      "id": "Monograph:Work:ClassificationNumbers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Library of Congress Classification",
+      "bfid": "lc:RT:bf2:LCC",
+      "uriBFLite": "lc",
+      "children": [
+        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:ClassificationNumber",
+        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AdditionalCallNumberInformation",
+        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AssigningAgency",
+        "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:UsedByAssigningAgency"
+      ],
+      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification"
+    },
+    {
+      "type": "literal",
+      "displayName": "Classification number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/code",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:ClassificationNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Additional call number information",
+      "uriBFLite": "http://bibfra.me/vocab/marc/itemNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AdditionalCallNumberInformation"
+    },
+    {
+      "type": "complex",
+      "displayName": "Assigning agency",
+      "uriBFLite": "_assigningSourceReference",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/organizations"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+        }
+      },
+      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:AssigningAgency"
+    },
+    {
+      "type": "simple",
+      "displayName": "Used by assigning agency?",
+      "uriBFLite": "http://bibfra.me/vocab/marc/status",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/mstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Monograph:Work:ClassificationNumbers:LibraryOfCongressClassification:UsedByAssigningAgency"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Dewey Decimal Classification",
+      "bfid": "lc:RT:bf2:DDC",
+      "uriBFLite": "ddc",
+      "children": [
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:ClassificationNumber",
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:AdditionalCallNumberInformation",
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyEditionNumber",
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyFullOrAbridged",
+        "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:Assigner"
+      ],
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification"
+    },
+    {
+      "type": "literal",
+      "displayName": "Classification number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/code",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:ClassificationNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Additional call number information",
+      "uriBFLite": "http://bibfra.me/vocab/marc/itemNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:AdditionalCallNumberInformation"
+    },
+    {
+      "type": "literal",
+      "displayName": "Dewey Edition number",
+      "uriBFLite": "http://bibfra.me/vocab/marc/editionNumber",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyEditionNumber"
+    },
+    {
+      "type": "literal",
+      "displayName": "Dewey full or abridged?",
+      "uriBFLite": "http://bibfra.me/vocab/marc/edition",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:DeweyFullOrAbridged"
+    },
+    {
+      "type": "complex",
+      "displayName": "Assigner",
+      "uriBFLite": "_assigningSourceReference",
+      "constraints": {
+        "repeatable": true,
+        "editable": false,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/organizations"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Agent"
+        }
+      },
+      "id": "Monograph:Work:ClassificationNumbers:DeweyDecimalClassification:Assigner"
+    },
+    {
+      "type": "simple",
+      "displayName": "Content Type",
+      "uriBFLite": "http://bibfra.me/vocab/marc/content",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/contentTypes"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Content"
+        }
+      },
+      "id": "Monograph:Work:ContentType"
+    },
+    {
+      "type": "simple",
+      "groupName": "Language",
+      "displayName": "Language code",
+      "uriBFLite": "http://bibfra.me/vocab/lite/language",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": ["http://id.loc.gov/vocabulary/languages"],
+        "valueDataType": { "remark": "", "dataTypeURI": "" }
+      },
+      "id": "Monograph:Work:LanguageCode"
+    }
+  ]
+}

--- a/src/test/java/org/folio/linked/data/e2e/PreferredProfileIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/PreferredProfileIT.java
@@ -38,7 +38,7 @@ class PreferredProfileIT {
       .headers(headers)
       .content("""
         {
-            "id": 1,
+            "id": 3,
             "resourceType": "http://bibfra.me/vocab/lite/Instance"
         }""");
     mockMvc.perform(postRequest)
@@ -71,7 +71,7 @@ class PreferredProfileIT {
     result
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$[0].id", equalTo(1)))
+      .andExpect(jsonPath("$[0].id", equalTo(3)))
       .andExpect(jsonPath("$[0].name", equalTo("Monograph")))
       .andExpect(jsonPath("$[0].resourceType", equalTo("http://bibfra.me/vocab/lite/Instance")))
       .andExpect(jsonPath("$.length()", equalTo(1)));

--- a/src/test/java/org/folio/linked/data/e2e/ProfileControllerIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/ProfileControllerIT.java
@@ -64,7 +64,7 @@ class ProfileControllerIT {
   @Test
   void getMetadataByResourceType_returnsMetadata() throws Exception {
     //given
-    var requestBuilder = get(PROFILE_URL + "/metadata?resourceType=http://bibfra.me/vocab/lite/Instance")
+    var requestBuilder = get(PROFILE_URL + "/metadata?resourceType=http://bibfra.me/vocab/lite/Work")
       .headers(defaultHeaders(env));
 
     //when
@@ -74,8 +74,8 @@ class ProfileControllerIT {
     resultActions
       .andExpect(status().isOk())
       .andExpect(content().contentType(APPLICATION_JSON))
-      .andExpect(jsonPath("$[0].id", equalTo(1)))
-      .andExpect(jsonPath("$[0].name", equalTo("Monograph")))
-      .andExpect(jsonPath("$[0].resourceType", equalTo("http://bibfra.me/vocab/lite/Instance")));
+      .andExpect(jsonPath("$[0].id", equalTo(2)))
+      .andExpect(jsonPath("$[0].name", equalTo("Work")))
+      .andExpect(jsonPath("$[0].resourceType", equalTo("http://bibfra.me/vocab/lite/Work")));
   }
 }

--- a/src/test/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImplTest.java
@@ -18,6 +18,8 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -90,19 +92,25 @@ class ResourceProfileLinkingServiceImplTest {
     assertThat(result).isEqualTo(profileId);
   }
 
-  @Test
-  void shouldResolveProfileId_returnMonographProfileId() {
+  @ParameterizedTest
+  @CsvSource({
+    "'http://bibfra.me/vocab/lite/Work', 2",
+    "'http://bibfra.me/vocab/lite/Instance', 3"
+  })
+  void shouldResolveProfileId_returnDefaultProfileId(String resourceTypeUri, int expectedProfileId) {
     // given
     var userId = randomUUID();
-    var resource = new Resource().setTypes(Set.of(new ResourceTypeEntity().setUri(INSTANCE.getUri()))).setId(1L);
+    var resource = new Resource()
+      .setTypes(Set.of(new ResourceTypeEntity().setUri(resourceTypeUri)))
+      .setId(1L);
     when(resourceProfileRepository.findProfileIdByResourceHash(resource.getId())).thenReturn(Optional.empty());
-    when(preferredProfileService.getPreferredProfiles(userId, INSTANCE.getUri())).thenReturn(List.of());
+    when(preferredProfileService.getPreferredProfiles(userId, resourceTypeUri)).thenReturn(List.of());
     when(folioExecutionContext.getUserId()).thenReturn(userId);
 
     // when
     var result = resourceProfileLinkingService.resolveProfileId(resource);
 
     // then
-    assertThat(result).isEqualTo(1);
+    assertThat(result).isEqualTo(expectedProfileId);
   }
 }


### PR DESCRIPTION
At present, "Monograph" profile contains the configuration for both Work and Instance resources.
For [UILD-578](https://folio-org.atlassian.net/browse/UILD-578), we need to split this into two separate profile JSONs. This PR implements this split.