### PR TITLE
MODLD-780: Add "on delete cascade" constraint to folio_metadata table. Remove method ResourceGraphService -> breakEdgesAndDelete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - Update API to support Award, Admin history, Biog data, Physical & Accmat Notes ([MODLD-520](https://folio-org.atlassian.net/browse/MODLD-520))
 - *BREAKING* Update okapiInterfaces for Split Search & Browse APIs. [MODLD-778](https://folio-org.atlassian.net/browse/MODLD-778)
 - Update API to support 'Series Statement' (MARC 490) [MODLD-777](https://folio-org.atlassian.net/browse/MODLD-777)
+- Add `on delete cascade` constraint to folio_metadata table. Remove method `ResourceGraphService -> breakEdgesAndDelete` [MODLD-780](https://folio-org.atlassian.net/browse/MODLD-780)
 
 ## 1.0.4 (04-24-2025)
 - Work Edit form - Instance read-only section: "Notes about the instance" data is not shown [MODLD-716](https://folio-org.atlassian.net/browse/MODLD-716)

--- a/src/main/java/org/folio/linked/data/model/entity/Resource.java
+++ b/src/main/java/org/folio/linked/data/model/entity/Resource.java
@@ -140,10 +140,7 @@ public class Resource implements Persistable<Long> {
       .map(outEdges -> outEdges.stream().map(ResourceEdge::new).collect(Collectors.toSet()))
       .orElse(null);
     this.incomingEdges = ofNullable(that.getIncomingEdges())
-      .map(inEdges -> inEdges.stream()
-        .map(
-          ie -> this.getOutgoingEdges().stream().filter(oe -> oe.equals(ie)).findFirst().orElse(new ResourceEdge(ie)))
-        .collect(Collectors.toSet()))
+      .map(inEdges -> inEdges.stream().map(ResourceEdge::new).collect(Collectors.toSet()))
       .orElse(null);
   }
 

--- a/src/main/java/org/folio/linked/data/service/resource/ResourceServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/ResourceServiceImpl.java
@@ -85,7 +85,7 @@ public class ResourceServiceImpl implements ResourceService {
     rejectInstanceOfAnotherWork(id, mapped);
     var existed = getResource(id);
     var oldResource = new Resource(existed);
-    resourceGraphService.breakEdgesAndDelete(existed);
+    resourceRepo.delete(existed);
     var newResource = updateResourceAndPublishEvents(mapped, oldResource, getProfileId(resourceDto));
     return resourceDtoMapper.toDto(newResource);
   }
@@ -94,7 +94,7 @@ public class ResourceServiceImpl implements ResourceService {
   public void deleteResource(Long id) {
     log.info("deleteResource [{}]", id);
     resourceRepo.findById(id).ifPresent(resource -> {
-      resourceGraphService.breakEdgesAndDelete(resource);
+      resourceRepo.delete(resource);
       applicationEventPublisher.publishEvent(new ResourceDeletedEvent(resource));
     });
   }

--- a/src/main/java/org/folio/linked/data/service/resource/graph/ResourceGraphService.java
+++ b/src/main/java/org/folio/linked/data/service/resource/graph/ResourceGraphService.java
@@ -9,7 +9,4 @@ public interface ResourceGraphService {
 
   Resource saveMergingGraph(Resource resource);
 
-  void breakEdgesAndDelete(Resource resource);
-
-
 }

--- a/src/main/java/org/folio/linked/data/service/resource/graph/ResourceGraphServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/graph/ResourceGraphServiceImpl.java
@@ -10,7 +10,6 @@ import static org.folio.linked.data.util.ResourceUtils.isPreferred;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.linked.data.domain.dto.ResourceGraphDto;
@@ -46,14 +45,6 @@ public class ResourceGraphServiceImpl implements ResourceGraphService {
   @Override
   public Resource saveMergingGraph(Resource resource) {
     return saveMergingGraphSkippingAlreadySaved(resource, null);
-  }
-
-  @Override
-  public void breakEdgesAndDelete(Resource resource) {
-    resource.setActive(false);
-    resource.setFolioMetadata(null);
-    breakCircularEdges(resource);
-    resourceRepo.delete(resource);
   }
 
   private Resource saveMergingGraphSkippingAlreadySaved(Resource resource, Resource saved) {
@@ -132,28 +123,5 @@ public class ResourceGraphServiceImpl implements ResourceGraphService {
       .map(ResourceEdge::getId)
       .map(id -> !edgeRepo.existsById(id))
       .orElse(false);
-  }
-
-  private void breakCircularEdges(Resource resource) {
-    breakOutgoingCircularEdges(resource);
-    breakIncomingCircularEdges(resource);
-  }
-
-  private void breakOutgoingCircularEdges(Resource resource) {
-    resource.getOutgoingEdges().forEach(edge -> {
-      var filtered = edge.getTarget().getIncomingEdges().stream()
-        .filter(e -> resource.equals(e.getSource()))
-        .collect(Collectors.toSet());
-      edge.getTarget().getIncomingEdges().removeAll(filtered);
-    });
-  }
-
-  private void breakIncomingCircularEdges(Resource resource) {
-    resource.getIncomingEdges().forEach(edge -> {
-      var filtered = edge.getSource().getOutgoingEdges().stream()
-        .filter(e -> resource.equals(e.getTarget()))
-        .collect(Collectors.toSet());
-      edge.getSource().getOutgoingEdges().removeAll(filtered);
-    });
   }
 }

--- a/src/main/resources/changelog/scripts/v-2.0.0/metadata/changelog.xml
+++ b/src/main/resources/changelog/scripts/v-2.0.0/metadata/changelog.xml
@@ -9,4 +9,5 @@
   <include file="tables/create-resource_profile-table.sql" relativeToChangelogFile="true"/>
   <include file="functions/resource_subgraph.sql" relativeToChangelogFile="true"/>
   <include file="tables/export_resources.sql" relativeToChangelogFile="true"/>
+  <include file="tables/upgrade_folio_metadata_on_delete_cascade.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/changelog/scripts/v-2.0.0/metadata/tables/upgrade_folio_metadata_on_delete_cascade.sql
+++ b/src/main/resources/changelog/scripts/v-2.0.0/metadata/tables/upgrade_folio_metadata_on_delete_cascade.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset pkjacob@ebsco.com:folio_metadata_on_delete_cascade dbms:postgresql
+alter table folio_metadata
+drop constraint if exists folio_metadata_resource_hash_fkey;
+
+alter table folio_metadata
+  add constraint folio_metadata_resource_hash_fkey
+    foreign key (resource_hash)
+      references resources(resource_hash)
+      on delete cascade;
+
+--rollback alter table folio_metadata drop constraint if exists folio_metadata_resource_hash_fkey;

--- a/src/test/java/org/folio/linked/data/service/resource/ResourceServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/ResourceServiceImplTest.java
@@ -261,7 +261,7 @@ class ResourceServiceImplTest {
 
     // then
     assertThat(expectedDto).isEqualTo(result);
-    verify(resourceGraphService).breakEdgesAndDelete(oldWork);
+    verify(resourceRepo).delete(oldWork);
     verify(resourceGraphService).saveMergingGraph(work);
     verify(folioExecutionContext).getUserId();
     verify(applicationEventPublisher).publishEvent(new ResourceUpdatedEvent(work));
@@ -297,7 +297,7 @@ class ResourceServiceImplTest {
 
     // then
     assertThat(expectedDto).isEqualTo(result);
-    verify(resourceGraphService).breakEdgesAndDelete(oldInstance);
+    verify(resourceRepo).delete(oldInstance);
     verify(resourceGraphService).saveMergingGraph(mapped);
     verify(applicationEventPublisher).publishEvent(new ResourceReplacedEvent(oldInstance, mapped.getId()));
     verify(resourceCopyService).copyEdgesAndProperties(oldInstance, mapped);
@@ -315,7 +315,7 @@ class ResourceServiceImplTest {
     resourceService.deleteResource(work.getId());
 
     // then
-    verify(resourceGraphService).breakEdgesAndDelete(work);
+    verify(resourceRepo).delete(work);
     var resourceDeletedEventCaptor = ArgumentCaptor.forClass(ResourceDeletedEvent.class);
     verify(applicationEventPublisher).publishEvent(resourceDeletedEventCaptor.capture());
     assertThat(work).isEqualTo(resourceDeletedEventCaptor.getValue().resource());
@@ -339,7 +339,7 @@ class ResourceServiceImplTest {
     resourceService.deleteResource(instance.getId());
 
     // then
-    verify(resourceGraphService).breakEdgesAndDelete(instance);
+    verify(resourceRepo).delete(instance);
     var resourceDeletedEventCaptor = ArgumentCaptor.forClass(ResourceDeletedEvent.class);
     verify(applicationEventPublisher).publishEvent(resourceDeletedEventCaptor.capture());
     assertThat(instance).isEqualTo(resourceDeletedEventCaptor.getValue().resource());


### PR DESCRIPTION
The `resource_edge` and `folio_metadata` tables have `ON DELETE CASCADE` & `orphanRemoval=true` constraints in both database and Java layers. 

As a result, their records will be automatically removed when a corresponding resource is deleted.

Therefore, the `ResourceGraphService → breakEdgesAndDelete` method is redundant and can be safely removed.