### PR TITLE
MODLD-795: New API to delete preferred profile for current user

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -173,6 +173,11 @@
           "methods": [ "POST" ],
           "pathPattern": "/linked-data/profile/preferred",
           "permissionsRequired": [ "linked-data.profiles.preferred.post" ]
+        },
+        {
+          "methods": [ "DELETE" ],
+          "pathPattern": "/linked-data/profile/preferred",
+          "permissionsRequired": [ "linked-data.profiles.preferred.delete" ]
         }
       ]
     },
@@ -300,6 +305,11 @@
       "permissionName": "linked-data.profiles.preferred.post",
       "displayName": "Linked Data: Create or update the preferred profile for a resource type for the current user",
       "description": "Create or update the preferred profile for a resource type for the current user"
+    },
+    {
+      "permissionName": "linked-data.profiles.preferred.delete",
+      "displayName": "Linked Data: Delete the preferred profile for a resource type for the current user",
+      "description": "Delete the preferred profile for a resource type for the current user"
     },
     {
       "permissionName": "linked-data.resources.rdf.get",

--- a/src/main/java/org/folio/linked/data/controller/ProfileController.java
+++ b/src/main/java/org/folio/linked/data/controller/ProfileController.java
@@ -1,7 +1,6 @@
 package org.folio.linked.data.controller;
 
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.folio.linked.data.domain.dto.PreferredProfileRequest;
 import org.folio.linked.data.domain.dto.ProfileMetadata;
@@ -29,13 +28,13 @@ public class ProfileController implements ProfileApi {
   }
 
   @Override
-  public ResponseEntity<Void> setPreferredProfile(UUID userId, PreferredProfileRequest preferredProfile) {
-    preferredProfileService.setPreferredProfile(userId, preferredProfile.getId(), preferredProfile.getResourceType());
+  public ResponseEntity<Void> setPreferredProfile(PreferredProfileRequest preferredProfile) {
+    preferredProfileService.setPreferredProfile(preferredProfile.getId(), preferredProfile.getResourceType());
     return ResponseEntity.noContent().build();
   }
 
   @Override
-  public ResponseEntity<List<ProfileMetadata>> getPreferredProfileByResourceType(UUID userId, String resourceTypeUri) {
-    return ResponseEntity.ok(preferredProfileService.getPreferredProfiles(userId, resourceTypeUri));
+  public ResponseEntity<List<ProfileMetadata>> getPreferredProfileByResourceType(String resourceTypeUri) {
+    return ResponseEntity.ok(preferredProfileService.getPreferredProfiles(resourceTypeUri));
   }
 }

--- a/src/main/java/org/folio/linked/data/controller/ProfileController.java
+++ b/src/main/java/org/folio/linked/data/controller/ProfileController.java
@@ -37,4 +37,10 @@ public class ProfileController implements ProfileApi {
   public ResponseEntity<List<ProfileMetadata>> getPreferredProfileByResourceType(String resourceTypeUri) {
     return ResponseEntity.ok(preferredProfileService.getPreferredProfiles(resourceTypeUri));
   }
+
+  @Override
+  public ResponseEntity<Void> deletePreferredProfile(String resourceTypeUri) {
+    preferredProfileService.deletePreferredProfile(resourceTypeUri);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/org/folio/linked/data/service/profile/PreferredProfileService.java
+++ b/src/main/java/org/folio/linked/data/service/profile/PreferredProfileService.java
@@ -1,12 +1,11 @@
 package org.folio.linked.data.service.profile;
 
 import java.util.List;
-import java.util.UUID;
 import org.folio.linked.data.domain.dto.ProfileMetadata;
 import org.springframework.lang.Nullable;
 
 public interface PreferredProfileService {
-  void setPreferredProfile(UUID userId, Integer profileId, String resourceTypeUri);
+  void setPreferredProfile(Integer profileId, String resourceTypeUri);
 
-  List<ProfileMetadata> getPreferredProfiles(UUID userId, @Nullable String resourceTypeUri);
+  List<ProfileMetadata> getPreferredProfiles(@Nullable String resourceTypeUri);
 }

--- a/src/main/java/org/folio/linked/data/service/profile/PreferredProfileService.java
+++ b/src/main/java/org/folio/linked/data/service/profile/PreferredProfileService.java
@@ -8,4 +8,6 @@ public interface PreferredProfileService {
   void setPreferredProfile(Integer profileId, String resourceTypeUri);
 
   List<ProfileMetadata> getPreferredProfiles(@Nullable String resourceTypeUri);
+
+  void deletePreferredProfile(String resourceTypeUri);
 }

--- a/src/main/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImpl.java
@@ -13,7 +13,6 @@ import org.folio.linked.data.exception.RequestProcessingExceptionBuilder;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceProfile;
 import org.folio.linked.data.repo.ResourceProfileRepository;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,7 +26,6 @@ public class ResourceProfileLinkingServiceImpl implements ResourceProfileLinking
 
   private final ResourceProfileRepository resourceProfileRepository;
   private final PreferredProfileService preferredProfileService;
-  private final FolioExecutionContext executionContext;
   private final RequestProcessingExceptionBuilder exceptionBuilder;
 
   @Override
@@ -58,7 +56,7 @@ public class ResourceProfileLinkingServiceImpl implements ResourceProfileLinking
 
   private Optional<Integer> getUserPreferredProfileId(ResourceType resourceType) {
     return preferredProfileService
-      .getPreferredProfiles(executionContext.getUserId(), resourceType.getUri())
+      .getPreferredProfiles(resourceType.getUri())
       .stream()
       .findFirst()
       .map(ProfileMetadata::getId);

--- a/src/main/resources/swagger.api/mod-linked-data.yaml
+++ b/src/main/resources/swagger.api/mod-linked-data.yaml
@@ -285,7 +285,6 @@ paths:
         - profile
       description: Get the preferred profile for a resource type for the current user
       parameters:
-        - $ref: '#/components/parameters/x-okapi-user-id-header'
         - name: resourceType
           in: query
           required: false
@@ -305,8 +304,6 @@ paths:
       tags:
         - profile
       description: Create or update the preferred profile for a resource type for the current user
-      parameters:
-        - $ref: '#/components/parameters/x-okapi-user-id-header'
       requestBody:
         content:
           application/json:
@@ -432,13 +429,6 @@ components:
       schema:
         type: integer
         format: int16
-    x-okapi-user-id-header:
-      name: x-okapi-user-id
-      in: header
-      description: X-Okapi-User-Id header value
-      schema:
-        type: string
-        format: uuid
   schemas:
     errorResponse:
       $ref: schema/error/errors.json

--- a/src/main/resources/swagger.api/mod-linked-data.yaml
+++ b/src/main/resources/swagger.api/mod-linked-data.yaml
@@ -310,13 +310,32 @@ paths:
             schema:
               $ref: "schema/profile/preferredProfileRequest.json"
       responses:
-        '200':
+        '204':
           description: Preferred profile created or updated successfully
         '400':
           $ref: '#/components/responses/badRequestResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
 
+    delete:
+      operationId: deletePreferredProfile
+      tags:
+        - profile
+      description: Delete preferred profile for current user
+      parameters:
+        - name: resourceType
+          in: query
+          required: true
+          description: The type of resource for which preferred profile has to be deleted.
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Preferred profile deleted successfully
+        '400':
+          $ref: '#/components/responses/badRequestResponse'
+        '500':
+          $ref: '#/components/responses/internalServerErrorResponse'
   /linked-data/resource/{id}/graph:
     get:
       operationId: getResourceGraphById

--- a/src/test/java/org/folio/linked/data/e2e/PreferredProfileIT.java
+++ b/src/test/java/org/folio/linked/data/e2e/PreferredProfileIT.java
@@ -4,6 +4,7 @@ import static java.util.UUID.randomUUID;
 import static org.folio.linked.data.test.TestUtil.defaultHeadersWithUserId;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -64,6 +65,34 @@ class PreferredProfileIT {
 
     // when
     validateEmptyPreferredProfile(mockMvc.perform(get(PREFERRED_PROFILE_URL).headers(headers)));
+  }
+
+  @Test
+  void shouldDeletePreferredProfile() throws Exception {
+    // given
+    var headers = defaultHeadersWithUserId(env, randomUUID().toString());
+    headers.setContentType(APPLICATION_JSON);
+
+    var postRequest = post(PREFERRED_PROFILE_URL)
+      .headers(headers)
+      .content("""
+        {
+            "id": 3,
+            "resourceType": "http://bibfra.me/vocab/lite/Instance"
+        }""");
+    mockMvc.perform(postRequest)
+      .andExpect(status().isNoContent());
+
+    var urlWithResourceType = PREFERRED_PROFILE_URL + "?resourceType=http://bibfra.me/vocab/lite/Instance";
+    validatePreferredProfile(mockMvc.perform(get(urlWithResourceType).headers(headers)));
+
+    // when
+    mockMvc.perform(delete(urlWithResourceType)
+      .headers(headers))
+      .andExpect(status().isNoContent());
+
+    // then
+    validateEmptyPreferredProfile(mockMvc.perform(get(urlWithResourceType).headers(headers)));
   }
 
   private void validatePreferredProfile(ResultActions result) throws Exception {

--- a/src/test/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/profile/ResourceProfileLinkingServiceImplTest.java
@@ -1,6 +1,5 @@
 package org.folio.linked.data.service.profile;
 
-import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.INSTANCE;
 import static org.mockito.Mockito.verify;
@@ -14,7 +13,6 @@ import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceProfile;
 import org.folio.linked.data.model.entity.ResourceTypeEntity;
 import org.folio.linked.data.repo.ResourceProfileRepository;
-import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,9 +29,6 @@ class ResourceProfileLinkingServiceImplTest {
 
   @Mock
   private ResourceProfileRepository resourceProfileRepository;
-
-  @Mock
-  private FolioExecutionContext folioExecutionContext;
 
   @Mock
   private PreferredProfileService preferredProfileService;
@@ -78,11 +73,9 @@ class ResourceProfileLinkingServiceImplTest {
   void shouldResolveProfileId_returnUserPreferredProfile() {
     // given
     var profileId = 2;
-    var userId = randomUUID();
     var resource = new Resource().setTypes(Set.of(new ResourceTypeEntity().setUri(INSTANCE.getUri()))).setId(1L);
     when(resourceProfileRepository.findProfileIdByResourceHash(resource.getId())).thenReturn(Optional.empty());
-    when(folioExecutionContext.getUserId()).thenReturn(userId);
-    when(preferredProfileService.getPreferredProfiles(userId, INSTANCE.getUri()))
+    when(preferredProfileService.getPreferredProfiles(INSTANCE.getUri()))
       .thenReturn(List.of(new ProfileMetadata(profileId, "", "")));
 
     // when
@@ -99,13 +92,11 @@ class ResourceProfileLinkingServiceImplTest {
   })
   void shouldResolveProfileId_returnDefaultProfileId(String resourceTypeUri, int expectedProfileId) {
     // given
-    var userId = randomUUID();
     var resource = new Resource()
       .setTypes(Set.of(new ResourceTypeEntity().setUri(resourceTypeUri)))
       .setId(1L);
     when(resourceProfileRepository.findProfileIdByResourceHash(resource.getId())).thenReturn(Optional.empty());
-    when(preferredProfileService.getPreferredProfiles(userId, resourceTypeUri)).thenReturn(List.of());
-    when(folioExecutionContext.getUserId()).thenReturn(userId);
+    when(preferredProfileService.getPreferredProfiles(resourceTypeUri)).thenReturn(List.of());
 
     // when
     var result = resourceProfileLinkingService.resolveProfileId(resource);


### PR DESCRIPTION
Commit 1: Refactor the existing profile related APIs to get current user Id from `FolioExecutionContext` rather than using `x-okapi-userId` header
Commit 2: Create new `DELETE /linked-data/profile/preferred` API