### PR TITLE
UILD-557: Fix: Complete removal of literal extent property from broken tests

### DIFF
--- a/src/test/java/org/folio/linked/data/mapper/resource/monograph/common/NoteMapperTest.java
+++ b/src/test/java/org/folio/linked/data/mapper/resource/monograph/common/NoteMapperTest.java
@@ -2,7 +2,6 @@ package org.folio.linked.data.mapper.resource.monograph.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.PropertyDictionary.DIMENSIONS;
-import static org.folio.ld.dictionary.PropertyDictionary.EXTENT;
 import static org.folio.ld.dictionary.PropertyDictionary.ISSUANCE_NOTE;
 import static org.folio.ld.dictionary.PropertyDictionary.NOTE;
 import static org.folio.ld.dictionary.PropertyDictionary.WITH_NOTE;
@@ -104,14 +103,12 @@ class NoteMapperTest {
 
   private static JsonNode createDocWithoutNotes() {
     var map = new HashMap<String, List<String>>();
-    putProperty(map, EXTENT, List.of("extent"));
     putProperty(map, DIMENSIONS, List.of("dimensions"));
     return OBJECT_MAPPER.convertValue(map, JsonNode.class);
   }
 
   private static JsonNode createDocWithNotes() {
     var map = new HashMap<String, List<String>>();
-    putProperty(map, EXTENT, List.of("extent"));
     putProperty(map, DIMENSIONS, List.of("dimensions"));
     putProperty(map, NOTE, List.of("general note"));
     putProperty(map, ISSUANCE_NOTE, List.of("issuance note", "another issuance note"));

--- a/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
+++ b/src/test/java/org/folio/linked/data/test/resource/ResourceJsonPath.java
@@ -7,6 +7,7 @@ import static org.folio.ld.dictionary.PredicateDictionary.CLASSIFICATION;
 import static org.folio.ld.dictionary.PredicateDictionary.CONTENT;
 import static org.folio.ld.dictionary.PredicateDictionary.COPYRIGHT;
 import static org.folio.ld.dictionary.PredicateDictionary.DISSERTATION;
+import static org.folio.ld.dictionary.PredicateDictionary.EXTENT;
 import static org.folio.ld.dictionary.PredicateDictionary.GOVERNMENT_PUBLICATION;
 import static org.folio.ld.dictionary.PredicateDictionary.ILLUSTRATIONS;
 import static org.folio.ld.dictionary.PredicateDictionary.LANGUAGE;
@@ -30,7 +31,6 @@ import static org.folio.ld.dictionary.PropertyDictionary.DISSERTATION_YEAR;
 import static org.folio.ld.dictionary.PropertyDictionary.EAN_VALUE;
 import static org.folio.ld.dictionary.PropertyDictionary.EDITION;
 import static org.folio.ld.dictionary.PropertyDictionary.EDITION_NUMBER;
-import static org.folio.ld.dictionary.PropertyDictionary.EXTENT;
 import static org.folio.ld.dictionary.PropertyDictionary.ISSUANCE;
 import static org.folio.ld.dictionary.PropertyDictionary.ITEM_NUMBER;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
@@ -102,7 +102,7 @@ public class ResourceJsonPath {
   }
 
   public static String toExtent() {
-    return String.join(".", toInstance(), arrayPath(EXTENT.getValue()));
+    return String.join(".", toInstance(), arrayPath(EXTENT.getUri()));
   }
 
   public static String toDimensions() {
@@ -122,16 +122,16 @@ public class ResourceJsonPath {
   }
 
   public static String toExtentLabel() {
-    return join(".", toInstance(), arrayPath(EXTENT.getValue()), arrayPath(LABEL.getValue()));
+    return join(".", toInstance(), arrayPath(EXTENT.getUri()), arrayPath(LABEL.getValue()));
   }
 
   public static String toExtentMaterialsSpec() {
-    return join(".", toInstance(), arrayPath(EXTENT.getValue()),
+    return join(".", toInstance(), arrayPath(EXTENT.getUri()),
       arrayPath(MATERIALS_SPECIFIED.getValue()));
   }
 
   public static String toExtentNote() {
-    return join(".", toInstance(), arrayPath(EXTENT.getValue()), arrayPath(NOTE.getValue()));
+    return join(".", toInstance(), arrayPath(EXTENT.getUri()), arrayPath(NOTE.getValue()));
   }
 
   public static String toAccessLocationLink() {


### PR DESCRIPTION
These imports were accidentally left in place and lead to compilation errors now that the actual dictionary entry has been removed from lib-linked-data-dictionary. Remove / adjust to correct.