### PR TITLE
MODLD-863: Persist admin metadata's outgoing edges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@
 - Computing default profile ID for Work and Instance [MODLD-854](https://folio-org.atlassian.net/browse/MODLD-854)
 - Update simple type field repeatability in profiles [MODLD-862](https://folio-org.atlassian.net/browse/MODLD-862)
 - Update export view to include inventory ID column [MODLD-860](https://folio-org.atlassian.net/browse/MODLD-860)
+- Save outgoing edges of admin metadata [MODLD-863](https://folio-org.atlassian.net/browse/MODLD-863)
 
 ## 1.0.4 (04-24-2025)
 - Work Edit form - Instance read-only section: "Notes about the instance" data is not shown [MODLD-716](https://folio-org.atlassian.net/browse/MODLD-716)

--- a/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeService.java
+++ b/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeService.java
@@ -12,6 +12,6 @@ public interface ResourceEdgeService {
 
   ResourceEdgePk saveNewResourceEdge(Long sourceId,
                                      PredicateDictionary predicate,
-                                     org.folio.ld.dictionary.model.Resource target);
+                                     org.folio.ld.dictionary.model.Resource targetModel);
 
 }

--- a/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeService.java
+++ b/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeService.java
@@ -1,7 +1,6 @@
 package org.folio.linked.data.service.resource.edge;
 
 import org.folio.ld.dictionary.PredicateDictionary;
-import org.folio.ld.dictionary.model.ResourceEdge;
 import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.pk.ResourceEdgePk;
 
@@ -11,6 +10,8 @@ public interface ResourceEdgeService {
 
   long deleteEdgesHavingPredicate(Long resourceId, PredicateDictionary predicatedToDelete);
 
-  ResourceEdgePk saveNewResourceEdge(Long sourceId, ResourceEdge edgeModel);
+  ResourceEdgePk saveNewResourceEdge(Long sourceId,
+                                     PredicateDictionary predicate,
+                                     org.folio.ld.dictionary.model.Resource target);
 
 }

--- a/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceImpl.java
@@ -51,7 +51,8 @@ public class ResourceEdgeServiceImpl implements ResourceEdgeService {
                                             org.folio.ld.dictionary.model.Resource target) {
     var sourceRef = new Resource().setId(sourceId);
     var targetEntity = resourceModelMapper.toEntity(target);
-    var savedTarget = resourceRepository.save(targetEntity);
+    var savedTarget = resourceRepository.findById(targetEntity.getId())
+      .orElse(resourceRepository.save(targetEntity));
     var edge = new ResourceEdge(sourceRef, savedTarget, new PredicateEntity(predicate));
     edge.computeId();
     return resourceEdgeRepository.save(edge).getId();

--- a/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceImpl.java
@@ -46,11 +46,13 @@ public class ResourceEdgeServiceImpl implements ResourceEdgeService {
   }
 
   @Override
-  public ResourceEdgePk saveNewResourceEdge(Long sourceId, org.folio.ld.dictionary.model.ResourceEdge edgeModel) {
+  public ResourceEdgePk saveNewResourceEdge(Long sourceId,
+                                            PredicateDictionary predicate,
+                                            org.folio.ld.dictionary.model.Resource target) {
     var sourceRef = new Resource().setId(sourceId);
-    var target = resourceModelMapper.toEntity(edgeModel.getTarget());
-    var savedTarget = resourceRepository.save(target);
-    var edge = new ResourceEdge(sourceRef, savedTarget, new PredicateEntity(edgeModel.getPredicate()));
+    var targetEntity = resourceModelMapper.toEntity(target);
+    var savedTarget = resourceRepository.save(targetEntity);
+    var edge = new ResourceEdge(sourceRef, savedTarget, new PredicateEntity(predicate));
     edge.computeId();
     return resourceEdgeRepository.save(edge).getId();
   }

--- a/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
@@ -131,11 +131,11 @@ public class ResourceMarcBibServiceImpl implements ResourceMarcBibService {
       log.info("Incoming Resource with id [{}] doesn't contain Inventory ID", modelResource.getId());
       return false;
     }
-    var adminMetadataEdge = modelResource.getOutgoingEdges().stream()
+    var adminEdge = modelResource.getOutgoingEdges().stream()
       .filter(re -> ADMIN_METADATA.equals(re.getPredicate()))
       .findFirst()
       .orElse(null);
-    if (isNull(adminMetadataEdge)) {
+    if (isNull(adminEdge)) {
       log.info("Incoming Resource with id [{}] doesn't contain AdminMetadata", modelResource.getId());
       return false;
     }
@@ -146,7 +146,12 @@ public class ResourceMarcBibServiceImpl implements ResourceMarcBibService {
     }
     var resourceId = idOptional.get().getId();
     removeExistingAdminMetadataIfAny(resourceId);
-    var edgeId = resourceEdgeService.saveNewResourceEdge(resourceId, adminMetadataEdge);
+    var edgeId = resourceEdgeService.saveNewResourceEdge(resourceId, adminEdge.getPredicate(), adminEdge.getTarget());
+    adminEdge.getTarget()
+      .getOutgoingEdges()
+      .forEach(
+        e -> resourceEdgeService.saveNewResourceEdge(e.getSource().getId(), e.getPredicate(), e.getTarget())
+      );
     log.info("New AdminMetadata has been added and saved under id [{}]", edgeId);
     return true;
   }

--- a/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
+++ b/src/main/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImpl.java
@@ -147,11 +147,6 @@ public class ResourceMarcBibServiceImpl implements ResourceMarcBibService {
     var resourceId = idOptional.get().getId();
     removeExistingAdminMetadataIfAny(resourceId);
     var edgeId = resourceEdgeService.saveNewResourceEdge(resourceId, adminEdge.getPredicate(), adminEdge.getTarget());
-    adminEdge.getTarget()
-      .getOutgoingEdges()
-      .forEach(
-        e -> resourceEdgeService.saveNewResourceEdge(e.getSource().getId(), e.getPredicate(), e.getTarget())
-      );
     log.info("New AdminMetadata has been added and saved under id [{}]", edgeId);
     return true;
   }

--- a/src/test/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceTest.java
@@ -58,7 +58,7 @@ class ResourceEdgeServiceTest {
       .thenAnswer(i -> i.getArguments()[0]);
 
     // when
-    var result = resourceEdgeService.saveNewResourceEdge(sourceId, edgeModel);
+    var result = resourceEdgeService.saveNewResourceEdge(sourceId, edgeModel.getPredicate(), edgeModel.getTarget());
 
     // then
     assertThat(result.getSourceHash()).isEqualTo(edgeModel.getSource().getId());

--- a/src/test/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/edge/ResourceEdgeServiceTest.java
@@ -19,7 +19,7 @@ import org.folio.linked.data.model.entity.Resource;
 import org.folio.linked.data.model.entity.ResourceEdge;
 import org.folio.linked.data.model.entity.ResourceTypeEntity;
 import org.folio.linked.data.repo.ResourceEdgeRepository;
-import org.folio.linked.data.repo.ResourceRepository;
+import org.folio.linked.data.service.resource.graph.ResourceGraphService;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +38,7 @@ class ResourceEdgeServiceTest {
   private ResourceEdgeServiceImpl resourceEdgeService;
 
   @Mock
-  private ResourceRepository resourceRepository;
+  private ResourceGraphService resourceGraphService;
   @Mock
   private ResourceModelMapper resourceModelMapper;
   @Mock
@@ -53,7 +53,7 @@ class ResourceEdgeServiceTest {
       new org.folio.ld.dictionary.model.Resource().setId(randomLong()), TITLE);
     var mappedEdgeResource = new org.folio.linked.data.model.entity.Resource().setId(edgeModel.getTarget().getId());
     doReturn(mappedEdgeResource).when(resourceModelMapper).toEntity(edgeModel.getTarget());
-    doReturn(mappedEdgeResource).when(resourceRepository).save(mappedEdgeResource);
+    doReturn(mappedEdgeResource).when(resourceGraphService).saveMergingGraph(mappedEdgeResource);
     when(resourceEdgeRepository.save(any(org.folio.linked.data.model.entity.ResourceEdge.class)))
       .thenAnswer(i -> i.getArguments()[0]);
 

--- a/src/test/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImplTest.java
@@ -3,9 +3,7 @@ package org.folio.linked.data.service.resource.marc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.folio.ld.dictionary.PredicateDictionary.ADMIN_METADATA;
-import static org.folio.ld.dictionary.PredicateDictionary.CATALOGING_LANGUAGE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ANNOTATION;
-import static org.folio.ld.dictionary.ResourceTypeDictionary.LANGUAGE_CATEGORY;
 import static org.folio.linked.data.model.entity.ResourceSource.LINKED_DATA;
 import static org.folio.linked.data.test.MonographTestUtil.getSampleInstanceResource;
 import static org.folio.linked.data.test.MonographTestUtil.getSampleWork;
@@ -429,17 +427,13 @@ class ResourceMarcBibServiceImplTest {
     // given
     var id = randomLong();
     var adminMetadata = new org.folio.ld.dictionary.model.Resource()
-      .setId(1L)
       .addType(ANNOTATION);
-    var language = new org.folio.ld.dictionary.model.Resource()
-      .addType(LANGUAGE_CATEGORY);
-    adminMetadata.addOutgoingEdge(new ResourceEdge(adminMetadata, language, CATALOGING_LANGUAGE));
     var folioMetadata = new FolioMetadata().setInventoryId(UUID.randomUUID().toString());
     var resourceModel = new org.folio.ld.dictionary.model.Resource()
       .setId(id)
       .setFolioMetadata(folioMetadata);
-    var adminEdge = new ResourceEdge(resourceModel, adminMetadata, ADMIN_METADATA);
-    resourceModel.addOutgoingEdge(adminEdge);
+    var edgeModel = new ResourceEdge(resourceModel, adminMetadata, ADMIN_METADATA);
+    resourceModel.addOutgoingEdge(edgeModel);
     doReturn(Optional.of((FolioMetadataRepository.IdOnly) () -> id))
       .when(folioMetadataRepo).findIdByInventoryId(folioMetadata.getInventoryId());
 
@@ -448,8 +442,7 @@ class ResourceMarcBibServiceImplTest {
 
     // then
     assertThat(result).isTrue();
-    verify(resourceEdgeService).saveNewResourceEdge(id, adminEdge.getPredicate(), adminEdge.getTarget());
-    verify(resourceEdgeService).saveNewResourceEdge(adminMetadata.getId(), CATALOGING_LANGUAGE, language);
+    verify(resourceEdgeService).saveNewResourceEdge(id, edgeModel.getPredicate(), edgeModel.getTarget());
     verify(resourceEdgeService).deleteEdgesHavingPredicate(id, ADMIN_METADATA);
   }
 

--- a/src/test/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImplTest.java
+++ b/src/test/java/org/folio/linked/data/service/resource/marc/ResourceMarcBibServiceImplTest.java
@@ -3,7 +3,9 @@ package org.folio.linked.data.service.resource.marc;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.folio.ld.dictionary.PredicateDictionary.ADMIN_METADATA;
+import static org.folio.ld.dictionary.PredicateDictionary.CATALOGING_LANGUAGE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.ANNOTATION;
+import static org.folio.ld.dictionary.ResourceTypeDictionary.LANGUAGE_CATEGORY;
 import static org.folio.linked.data.model.entity.ResourceSource.LINKED_DATA;
 import static org.folio.linked.data.test.MonographTestUtil.getSampleInstanceResource;
 import static org.folio.linked.data.test.MonographTestUtil.getSampleWork;
@@ -427,13 +429,17 @@ class ResourceMarcBibServiceImplTest {
     // given
     var id = randomLong();
     var adminMetadata = new org.folio.ld.dictionary.model.Resource()
+      .setId(1L)
       .addType(ANNOTATION);
+    var language = new org.folio.ld.dictionary.model.Resource()
+      .addType(LANGUAGE_CATEGORY);
+    adminMetadata.addOutgoingEdge(new ResourceEdge(adminMetadata, language, CATALOGING_LANGUAGE));
     var folioMetadata = new FolioMetadata().setInventoryId(UUID.randomUUID().toString());
     var resourceModel = new org.folio.ld.dictionary.model.Resource()
       .setId(id)
       .setFolioMetadata(folioMetadata);
-    var edgeModel = new ResourceEdge(resourceModel, adminMetadata, ADMIN_METADATA);
-    resourceModel.addOutgoingEdge(edgeModel);
+    var adminEdge = new ResourceEdge(resourceModel, adminMetadata, ADMIN_METADATA);
+    resourceModel.addOutgoingEdge(adminEdge);
     doReturn(Optional.of((FolioMetadataRepository.IdOnly) () -> id))
       .when(folioMetadataRepo).findIdByInventoryId(folioMetadata.getInventoryId());
 
@@ -442,7 +448,8 @@ class ResourceMarcBibServiceImplTest {
 
     // then
     assertThat(result).isTrue();
-    verify(resourceEdgeService).saveNewResourceEdge(id, edgeModel);
+    verify(resourceEdgeService).saveNewResourceEdge(id, adminEdge.getPredicate(), adminEdge.getTarget());
+    verify(resourceEdgeService).saveNewResourceEdge(adminMetadata.getId(), CATALOGING_LANGUAGE, language);
     verify(resourceEdgeService).deleteEdgesHavingPredicate(id, ADMIN_METADATA);
   }
 


### PR DESCRIPTION
Earlier, we were not persisting adminMetadata's outgoing edges.
This PR fixes the problem.