### PR TITLE
MODLD-1073 - Tooltip displays incorrect MARC equivalents

### DIFF
--- a/src/main/resources/profiles/instance-monograph.json
+++ b/src/main/resources/profiles/instance-monograph.json
@@ -1128,7 +1128,7 @@
         "valueDataType": {}
       },
       "id": "Profile:Instance:NotesAboutTheInstance:Note",
-      "marc": "5XX"
+      "marc": "3XX, 5XX"
     },
     {
       "type": "simple",

--- a/src/main/resources/profiles/instance-monograph.json
+++ b/src/main/resources/profiles/instance-monograph.json
@@ -1332,7 +1332,7 @@
         "valueDataType": {}
       },
       "id": "Profile:Instance:URLOfInstance:Note",
-      "marc": "856 $x"
+      "marc": "856 $z"
     },
     {
       "type": "group",

--- a/src/main/resources/profiles/instance-rare-books.json
+++ b/src/main/resources/profiles/instance-rare-books.json
@@ -1128,7 +1128,7 @@
         "valueDataType": {}
       },
       "id": "Profile:Instance:NotesAboutTheInstance:Note",
-      "marc": "5XX"
+      "marc": "3XX, 5XX"
     },
     {
       "type": "simple",

--- a/src/main/resources/profiles/instance-serials.json
+++ b/src/main/resources/profiles/instance-serials.json
@@ -1333,7 +1333,7 @@
         "valueDataType": {}
       },
       "id": "Profile:Instance:URLOfInstance:Note",
-      "marc": "856 $x"
+      "marc": "856 $z"
     },
     {
       "type": "simple",

--- a/src/main/resources/profiles/instance-serials.json
+++ b/src/main/resources/profiles/instance-serials.json
@@ -1129,7 +1129,7 @@
         "valueDataType": {}
       },
       "id": "Profile:Instance:NotesAboutTheInstance:Note",
-      "marc": "5XX"
+      "marc": "3XX, 5XX"
     },
     {
       "type": "simple",

--- a/src/main/resources/profiles/work-books.json
+++ b/src/main/resources/profiles/work-books.json
@@ -651,7 +651,7 @@
         }
       },
       "id": "Profile:Work:SupplementaryContent",
-      "marc": "008/24-27"
+      "marc": "008/24-27, 31"
     },
     {
       "type": "literal",

--- a/src/main/resources/profiles/work-serials.json
+++ b/src/main/resources/profiles/work-serials.json
@@ -649,7 +649,8 @@
           "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/SupplementaryContent"
         }
       },
-      "id": "Profile:Work:SupplementaryContent"
+      "id": "Profile:Work:SupplementaryContent",
+      "marc": "008/24-27, 31"
     },
     {
       "type": "literal",


### PR DESCRIPTION
[MODLD-1073](https://folio-org.atlassian.net/browse/MODLD-1073) - Tooltip displays incorrect MARC equivalents