### PR TITLE
MODLD-1083: Update authority profiles

### DIFF
--- a/src/main/resources/profiles/authority-family.json
+++ b/src/main/resources/profiles/authority-family.json
@@ -16,7 +16,8 @@
         "Profile:Authority:MiscellaneousInformation",
         "Profile:Authority:AttributionQualifier",
         "Profile:Authority:FullerFormOfName",
-        "Profile:Authority:Affiliation"
+        "Profile:Authority:Affiliation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -139,6 +140,141 @@
       },
       "id": "Profile:Authority:Affiliation",
       "marc": "700$u"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-family.json
+++ b/src/main/resources/profiles/authority-family.json
@@ -3,144 +3,142 @@
   "name": "Family",
   "resourceType": "http://bibfra.me/vocab/lite/Family",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Family",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:FamilyName",
-          "Profile:Authority:Numeration",
-          "Profile:Authority:Titles",
-          "Profile:Authority:Dates",
-          "Profile:Authority:MiscellaneousInformation",
-          "Profile:Authority:AttributionQualifier",
-          "Profile:Authority:FullerFormOfName",
-          "Profile:Authority:Affiliation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Family",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:FamilyName",
+        "Profile:Authority:Numeration",
+        "Profile:Authority:Titles",
+        "Profile:Authority:Dates",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:AttributionQualifier",
+        "Profile:Authority:FullerFormOfName",
+        "Profile:Authority:Affiliation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Family Name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Family Name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:FamilyName",
-        "marc": "100/700$a"
+      "id": "Profile:Authority:FamilyName",
+      "marc": "100/700$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Numeration",
+      "uriBFLite": "http://bibfra.me/vocab/library/numeration",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Numeration",
-        "uriBFLite": "http://bibfra.me/vocab/library/numeration",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Numeration",
-        "marc": "100/700$b"
+      "id": "Profile:Authority:Numeration",
+      "marc": "100/700$b"
+    },
+    {
+      "type": "literal",
+      "displayName": "Titles",
+      "uriBFLite": "http://bibfra.me/vocab/library/titles",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Titles",
-        "uriBFLite": "http://bibfra.me/vocab/library/titles",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Titles",
-        "marc": "100/700$c"
+      "id": "Profile:Authority:Titles",
+      "marc": "100/700$c"
+    },
+    {
+      "type": "literal",
+      "displayName": "Dates",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Dates",
-        "uriBFLite": "http://bibfra.me/vocab/lite/date",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Dates",
-        "marc": "100/700$d"
+      "id": "Profile:Authority:Dates",
+      "marc": "100/700$d"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "100/700$g"
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "100/700$g"
+    },
+    {
+      "type": "literal",
+      "displayName": "Attribution qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/attribution",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Attribution qualifier",
-        "uriBFLite": "http://bibfra.me/vocab/library/attribution",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:AttributionQualifier",
-        "marc": "100/700$j"
+      "id": "Profile:Authority:AttributionQualifier",
+      "marc": "100/700$j"
+    },
+    {
+      "type": "literal",
+      "displayName": "Fuller form of name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/nameAlternative",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Fuller form of name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/nameAlternative",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:FullerFormOfName",
-        "marc": "100/700$q"
+      "id": "Profile:Authority:FullerFormOfName",
+      "marc": "100/700$q"
+    },
+    {
+      "type": "literal",
+      "displayName": "Affiliation",
+      "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Affiliation",
-        "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Affiliation",
-        "marc": "700$u"
-      }
-    ]
+      "id": "Profile:Authority:Affiliation",
+      "marc": "700$u"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-form.json
+++ b/src/main/resources/profiles/authority-form.json
@@ -8,7 +8,7 @@
       "displayName": "Form",
       "bfid": "lde:Profile:Authority",
       "uriBFLite": "_authority",
-      "children": ["Profile:Authority:GenreFormTerm"],
+      "children": ["Profile:Authority:GenreFormTerm", "Profile:Authority:Identifiers"],
       "id": "Profile:Authority"
     },
     {
@@ -25,6 +25,141 @@
       },
       "id": "Profile:Authority:GenreFormTerm",
       "marc": "155/755$a"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-form.json
+++ b/src/main/resources/profiles/authority-form.json
@@ -3,32 +3,28 @@
   "name": "Form",
   "resourceType": "http://bibfra.me/vocab/lite/Form",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Form",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:GenreFormTerm"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Form",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": ["Profile:Authority:GenreFormTerm"],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Genre/form term",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Genre/form term",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:GenreFormTerm",
-        "marc": "155/755$a"
-      }
-    ]
+      "id": "Profile:Authority:GenreFormTerm",
+      "marc": "155/755$a"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-jurisdiction.json
+++ b/src/main/resources/profiles/authority-jurisdiction.json
@@ -14,7 +14,8 @@
         "Profile:Authority:Location",
         "Profile:Authority:Date",
         "Profile:Authority:MiscellaneousInformation",
-        "Profile:Authority:Affiliation"
+        "Profile:Authority:Affiliation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -107,6 +108,141 @@
       },
       "id": "Profile:Authority:Affiliation",
       "marc": "710$u"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-jurisdiction.json
+++ b/src/main/resources/profiles/authority-jurisdiction.json
@@ -3,112 +3,110 @@
   "name": "Jurisdiction",
   "resourceType": "http://bibfra.me/vocab/lite/Jurisdiction",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Jurisdiction",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:JurisdictionName",
-          "Profile:Authority:SubordinateUnit",
-          "Profile:Authority:Location",
-          "Profile:Authority:Date",
-          "Profile:Authority:MiscellaneousInformation",
-          "Profile:Authority:Affiliation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Jurisdiction",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:JurisdictionName",
+        "Profile:Authority:SubordinateUnit",
+        "Profile:Authority:Location",
+        "Profile:Authority:Date",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:Affiliation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Jurisdiction name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Jurisdiction name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:JurisdictionName",
-        "marc": "110/710$a"
+      "id": "Profile:Authority:JurisdictionName",
+      "marc": "110/710$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Subordinate unit",
+      "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Subordinate unit",
-        "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:SubordinateUnit",
-        "marc": "110/710$b"
+      "id": "Profile:Authority:SubordinateUnit",
+      "marc": "110/710$b"
+    },
+    {
+      "type": "literal",
+      "displayName": "Location",
+      "uriBFLite": "http://bibfra.me/vocab/library/place",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Location",
-        "uriBFLite": "http://bibfra.me/vocab/library/place",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Location",
-        "marc": "110/710$c"
+      "id": "Profile:Authority:Location",
+      "marc": "110/710$c"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Date",
-        "uriBFLite": "http://bibfra.me/vocab/lite/date",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Date",
-        "marc": "110/710$d"
+      "id": "Profile:Authority:Date",
+      "marc": "110/710$d"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "110/710$g"
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "110/710$g"
+    },
+    {
+      "type": "literal",
+      "displayName": "Affiliation",
+      "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Affiliation",
-        "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Affiliation",
-        "marc": "710$u"
-      }
-    ]
+      "id": "Profile:Authority:Affiliation",
+      "marc": "710$u"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-meeting.json
+++ b/src/main/resources/profiles/authority-meeting.json
@@ -3,112 +3,110 @@
   "name": "Meeting",
   "resourceType": "http://bibfra.me/vocab/lite/Meeting",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Meeting",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:MeetingName",
-          "Profile:Authority:Location",
-          "Profile:Authority:Date",
-          "Profile:Authority:SubordinateUnit",
-          "Profile:Authority:MiscellaneousInformation",
-          "Profile:Authority:Affiliation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Meeting",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:MeetingName",
+        "Profile:Authority:Location",
+        "Profile:Authority:Date",
+        "Profile:Authority:SubordinateUnit",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:Affiliation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Meeting name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Meeting name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MeetingName",
-        "marc": "111/711$a"
+      "id": "Profile:Authority:MeetingName",
+      "marc": "111/711$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Location",
+      "uriBFLite": "http://bibfra.me/vocab/library/place",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Location",
-        "uriBFLite": "http://bibfra.me/vocab/library/place",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Location",
-        "marc": "111/711$c"
+      "id": "Profile:Authority:Location",
+      "marc": "111/711$c"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Date",
-        "uriBFLite": "http://bibfra.me/vocab/lite/date",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Date",
-        "marc": "111/711$d"
+      "id": "Profile:Authority:Date",
+      "marc": "111/711$d"
+    },
+    {
+      "type": "literal",
+      "displayName": "Subordinate unit",
+      "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Subordinate unit",
-        "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:SubordinateUnit",
-        "marc": "111/711$e"
+      "id": "Profile:Authority:SubordinateUnit",
+      "marc": "111/711$e"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "111/711$g"
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "111/711$g"
+    },
+    {
+      "type": "literal",
+      "displayName": "Affiliation",
+      "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Affiliation",
-        "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Affiliation",
-        "marc": "711$u"
-      }
-    ]
+      "id": "Profile:Authority:Affiliation",
+      "marc": "711$u"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-meeting.json
+++ b/src/main/resources/profiles/authority-meeting.json
@@ -14,7 +14,8 @@
         "Profile:Authority:Date",
         "Profile:Authority:SubordinateUnit",
         "Profile:Authority:MiscellaneousInformation",
-        "Profile:Authority:Affiliation"
+        "Profile:Authority:Affiliation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -107,6 +108,141 @@
       },
       "id": "Profile:Authority:Affiliation",
       "marc": "711$u"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-organization.json
+++ b/src/main/resources/profiles/authority-organization.json
@@ -14,7 +14,8 @@
         "Profile:Authority:Location",
         "Profile:Authority:Date",
         "Profile:Authority:MiscellaneousInformation",
-        "Profile:Authority:Affiliation"
+        "Profile:Authority:Affiliation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -107,6 +108,141 @@
       },
       "id": "Profile:Authority:Affiliation",
       "marc": "710$u"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-organization.json
+++ b/src/main/resources/profiles/authority-organization.json
@@ -3,112 +3,110 @@
   "name": "Organization",
   "resourceType": "http://bibfra.me/vocab/lite/Organization",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Organization",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:CorporateName",
-          "Profile:Authority:SubordinateUnit",
-          "Profile:Authority:Location",
-          "Profile:Authority:Date",
-          "Profile:Authority:MiscellaneousInformation",
-          "Profile:Authority:Affiliation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Organization",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:CorporateName",
+        "Profile:Authority:SubordinateUnit",
+        "Profile:Authority:Location",
+        "Profile:Authority:Date",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:Affiliation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Corporate name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Corporate name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:CorporateName",
-        "marc": "110/710$a"
+      "id": "Profile:Authority:CorporateName",
+      "marc": "110/710$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Subordinate unit",
+      "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Subordinate unit",
-        "uriBFLite": "http://bibfra.me/vocab/library/subordinateUnit",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:SubordinateUnit",
-        "marc": "110/710$b"
+      "id": "Profile:Authority:SubordinateUnit",
+      "marc": "110/710$b"
+    },
+    {
+      "type": "literal",
+      "displayName": "Location",
+      "uriBFLite": "http://bibfra.me/vocab/library/place",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Location",
-        "uriBFLite": "http://bibfra.me/vocab/library/place",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Location",
-        "marc": "110/710$c"
+      "id": "Profile:Authority:Location",
+      "marc": "110/710$c"
+    },
+    {
+      "type": "literal",
+      "displayName": "Date",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Date",
-        "uriBFLite": "http://bibfra.me/vocab/lite/date",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Date",
-        "marc": "110/710$d"
+      "id": "Profile:Authority:Date",
+      "marc": "110/710$d"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "110/710$g"
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "110/710$g"
+    },
+    {
+      "type": "literal",
+      "displayName": "Affiliation",
+      "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Affiliation",
-        "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Affiliation",
-        "marc": "710$u"
-      }
-    ]
+      "id": "Profile:Authority:Affiliation",
+      "marc": "710$u"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-person.json
+++ b/src/main/resources/profiles/authority-person.json
@@ -16,7 +16,8 @@
         "Profile:Authority:MiscellaneousInformation",
         "Profile:Authority:AttributionQualifier",
         "Profile:Authority:FullerFormOfName",
-        "Profile:Authority:Affiliation"
+        "Profile:Authority:Affiliation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -139,6 +140,141 @@
       },
       "id": "Profile:Authority:Affiliation",
       "marc": "700$u"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-person.json
+++ b/src/main/resources/profiles/authority-person.json
@@ -3,144 +3,142 @@
   "name": "Person",
   "resourceType": "http://bibfra.me/vocab/lite/Person",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Person",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:PersonalName",
-          "Profile:Authority:Numeration",
-          "Profile:Authority:Titles",
-          "Profile:Authority:Dates",
-          "Profile:Authority:MiscellaneousInformation",
-          "Profile:Authority:AttributionQualifier",
-          "Profile:Authority:FullerFormOfName",
-          "Profile:Authority:Affiliation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Person",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:PersonalName",
+        "Profile:Authority:Numeration",
+        "Profile:Authority:Titles",
+        "Profile:Authority:Dates",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:AttributionQualifier",
+        "Profile:Authority:FullerFormOfName",
+        "Profile:Authority:Affiliation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Personal name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Personal name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:PersonalName",
-        "marc": "100/700$a"
+      "id": "Profile:Authority:PersonalName",
+      "marc": "100/700$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Numeration",
+      "uriBFLite": "http://bibfra.me/vocab/library/numeration",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Numeration",
-        "uriBFLite": "http://bibfra.me/vocab/library/numeration",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Numeration",
-        "marc": "100/700$b"
+      "id": "Profile:Authority:Numeration",
+      "marc": "100/700$b"
+    },
+    {
+      "type": "literal",
+      "displayName": "Titles",
+      "uriBFLite": "http://bibfra.me/vocab/library/titles",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Titles",
-        "uriBFLite": "http://bibfra.me/vocab/library/titles",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Titles",
-        "marc": "100/700$c"
+      "id": "Profile:Authority:Titles",
+      "marc": "100/700$c"
+    },
+    {
+      "type": "literal",
+      "displayName": "Dates",
+      "uriBFLite": "http://bibfra.me/vocab/lite/date",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Dates",
-        "uriBFLite": "http://bibfra.me/vocab/lite/date",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Dates",
-        "marc": "100/700$d"
+      "id": "Profile:Authority:Dates",
+      "marc": "100/700$d"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "100/700$g"
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "100/700$g"
+    },
+    {
+      "type": "literal",
+      "displayName": "Attribution qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/attribution",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Attribution qualifier",
-        "uriBFLite": "http://bibfra.me/vocab/library/attribution",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:AttributionQualifier",
-        "marc": "100/700$j"
+      "id": "Profile:Authority:AttributionQualifier",
+      "marc": "100/700$j"
+    },
+    {
+      "type": "literal",
+      "displayName": "Fuller form of name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/nameAlternative",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Fuller form of name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/nameAlternative",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:FullerFormOfName",
-        "marc": "100/700$q"
+      "id": "Profile:Authority:FullerFormOfName",
+      "marc": "100/700$q"
+    },
+    {
+      "type": "literal",
+      "displayName": "Affiliation",
+      "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Affiliation",
-        "uriBFLite": "http://bibfra.me/vocab/scholar/affiliation",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:Affiliation",
-        "marc": "700$u"
-      }
-    ]
+      "id": "Profile:Authority:Affiliation",
+      "marc": "700$u"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-place.json
+++ b/src/main/resources/profiles/authority-place.json
@@ -8,7 +8,11 @@
       "displayName": "Place",
       "bfid": "lde:Profile:Authority",
       "uriBFLite": "_authority",
-      "children": ["Profile:Authority:GeographicName", "Profile:Authority:MiscellaneousInformation"],
+      "children": [
+        "Profile:Authority:GeographicName",
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:Identifiers"
+      ],
       "id": "Profile:Authority"
     },
     {
@@ -40,6 +44,141 @@
       },
       "id": "Profile:Authority:MiscellaneousInformation",
       "marc": "151/751$g"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-place.json
+++ b/src/main/resources/profiles/authority-place.json
@@ -3,48 +3,43 @@
   "name": "Place",
   "resourceType": "http://bibfra.me/vocab/lite/Place",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Place",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:GeographicName",
-          "Profile:Authority:MiscellaneousInformation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Place",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": ["Profile:Authority:GeographicName", "Profile:Authority:MiscellaneousInformation"],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Geographic name",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Geographic name",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:GeographicName",
-        "marc": "151/751$a"
+      "id": "Profile:Authority:GeographicName",
+      "marc": "151/751$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "151/751$g"
-      }
-    ]
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "151/751$g"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-temporal.json
+++ b/src/main/resources/profiles/authority-temporal.json
@@ -8,7 +8,7 @@
       "displayName": "Temporal",
       "bfid": "lde:Profile:Authority",
       "uriBFLite": "_authority",
-      "children": ["Profile:Authority:ChronologicalTerm"],
+      "children": ["Profile:Authority:ChronologicalTerm", "Profile:Authority:Identifiers"],
       "id": "Profile:Authority"
     },
     {
@@ -25,6 +25,141 @@
       },
       "id": "Profile:Authority:ChronologicalTerm",
       "marc": "648$a"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }

--- a/src/main/resources/profiles/authority-temporal.json
+++ b/src/main/resources/profiles/authority-temporal.json
@@ -3,32 +3,28 @@
   "name": "Temporal",
   "resourceType": "http://bibfra.me/vocab/lite/Temporal",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Temporal",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:ChronologicalTerm"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Temporal",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": ["Profile:Authority:ChronologicalTerm"],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Chronological term",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Chronological term",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:ChronologicalTerm",
-        "marc": "648$a"
-      }
-    ]
+      "id": "Profile:Authority:ChronologicalTerm",
+      "marc": "648$a"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-topic.json
+++ b/src/main/resources/profiles/authority-topic.json
@@ -3,64 +3,62 @@
   "name": "Topic",
   "resourceType": "http://bibfra.me/vocab/lite/Topic",
   "value": [
-    [
-      {
-        "type": "block",
-        "displayName": "Topic",
-        "bfid": "lde:Profile:Authority",
-        "uriBFLite": "_authority",
-        "children": [
-          "Profile:Authority:TopicalTerm",
-          "Profile:Authority:GeographicName",
-          "Profile:Authority:MiscellaneousInformation"
-        ],
-        "id": "Profile:Authority"
+    {
+      "type": "block",
+      "displayName": "Topic",
+      "bfid": "lde:Profile:Authority",
+      "uriBFLite": "_authority",
+      "children": [
+        "Profile:Authority:TopicalTerm",
+        "Profile:Authority:GeographicName",
+        "Profile:Authority:MiscellaneousInformation"
+      ],
+      "id": "Profile:Authority"
+    },
+    {
+      "type": "literal",
+      "displayName": "Topical term",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Topical term",
-        "uriBFLite": "http://bibfra.me/vocab/lite/name",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:TopicalTerm",
-        "marc": "150/750$a"
+      "id": "Profile:Authority:TopicalTerm",
+      "marc": "150/750$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Geographic name",
+      "uriBFLite": "http://bibfra.me/vocab/library/geographicCoverage",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": true,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Geographic name",
-        "uriBFLite": "http://bibfra.me/vocab/library/geographicCoverage",
-        "constraints": {
-          "repeatable": false,
-          "editable": true,
-          "mandatory": true,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:GeographicName",
-        "marc": "150/750$a"
+      "id": "Profile:Authority:GeographicName",
+      "marc": "150/750$a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Miscellaneous information",
+      "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
       },
-      {
-        "type": "literal",
-        "displayName": "Miscellaneous information",
-        "uriBFLite": "http://bibfra.me/vocab/library/miscInfo",
-        "constraints": {
-          "repeatable": true,
-          "editable": true,
-          "mandatory": false,
-          "defaults": [],
-          "useValuesFrom": [],
-          "valueDataType": {}
-        },
-        "id": "Profile:Authority:MiscellaneousInformation",
-        "marc": "150/750$g"
-      }
-    ]
+      "id": "Profile:Authority:MiscellaneousInformation",
+      "marc": "150/750$g"
+    }
   ]
 }

--- a/src/main/resources/profiles/authority-topic.json
+++ b/src/main/resources/profiles/authority-topic.json
@@ -11,7 +11,8 @@
       "children": [
         "Profile:Authority:TopicalTerm",
         "Profile:Authority:GeographicName",
-        "Profile:Authority:MiscellaneousInformation"
+        "Profile:Authority:MiscellaneousInformation",
+        "Profile:Authority:Identifiers"
       ],
       "id": "Profile:Authority"
     },
@@ -59,6 +60,141 @@
       },
       "id": "Profile:Authority:MiscellaneousInformation",
       "marc": "150/750$g"
+    },
+    {
+      "type": "dropdown",
+      "displayName": "Identifiers",
+      "uriBFLite": "http://library.link/vocab/map",
+      "constraints": {
+        "repeatable": true,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "children": ["Profile:Authority:Identifiers:LCCN", "Profile:Authority:Identifiers:OtherIdentifier"],
+      "id": "Profile:Authority:Identifiers"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "LCCN",
+      "bfid": "lc:RT:bf2:Identifiers:LCCN",
+      "uriBFLite": "http://library.link/identifier/LCCN",
+      "children": [
+        "Profile:Authority:Identifiers:LCCN:LCCN",
+        "Profile:Authority:Identifiers:LCCN:Qualifier",
+        "Profile:Authority:Identifiers:LCCN:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:LCCN",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "LCCN",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:LCCN",
+      "marc": "010 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:LCCN:InvalidCanceled",
+      "marc": "010 $z"
+    },
+    {
+      "type": "dropdownOption",
+      "displayName": "Other Identifier",
+      "bfid": "lc:RT:bf2:Identifiers:OtherIdentifier",
+      "uriBFLite": "http://library.link/identifier/UNKNOWN",
+      "children": [
+        "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+        "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled"
+      ],
+      "id": "Profile:Authority:Identifiers:OtherIdentifier",
+      "marc": "N/A"
+    },
+    {
+      "type": "literal",
+      "displayName": "Other Identifier",
+      "uriBFLite": "http://bibfra.me/vocab/lite/name",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:OtherIdentifier",
+      "marc": "024 _8 $a"
+    },
+    {
+      "type": "literal",
+      "displayName": "Qualifier",
+      "uriBFLite": "http://bibfra.me/vocab/library/qualifier",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": [],
+        "valueDataType": {}
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:Qualifier",
+      "marc": "024 _8 $q"
+    },
+    {
+      "type": "simple",
+      "displayName": "Invalid/Canceled?",
+      "uriBFLite": "http://bibfra.me/vocab/library/status",
+      "constraints": {
+        "repeatable": false,
+        "editable": true,
+        "mandatory": false,
+        "defaults": [],
+        "useValuesFrom": ["/linked-data/vocabularies/idstatus"],
+        "valueDataType": {
+          "dataTypeURI": "http://id.loc.gov/ontologies/bibframe/Status"
+        }
+      },
+      "id": "Profile:Authority:Identifiers:OtherIdentifier:InvalidCanceled",
+      "marc": "024 _8 $z"
     }
   ]
 }


### PR DESCRIPTION
Update authority profiles to simplify the structure by removing unnecessary array nesting.
Add Identifiers section to authority profiles.

[https://folio-org.atlassian.net/browse/MODLD-1083](https://folio-org.atlassian.net/browse/MODLD-1083)