### PR TITLE
MODLD-1040: Fix path for creating profile settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -175,14 +175,14 @@
           "permissionsRequired": [ "linked-data.profiles.settings.list.get" ]
         },
         {
+          "methods": [ "POST" ],
+          "pathPattern": "/linked-data/profile/{profileId}/settings",
+          "permissionsRequired": [ "linked-data.profiles.settings.post" ]
+        },
+        {
           "methods": [ "GET" ],
           "pathPattern": "/linked-data/profile/{profileId}/settings/{id}",
           "permissionsRequired": [ "linked-data.profiles.settings.get" ]
-        },
-        {
-          "methods": [ "POST" ],
-          "pathPattern": "/linked-data/profile/{profileId}/settings/{id}",
-          "permissionsRequired": [ "linked-data.profiles.settings.post" ]
         },
         {
           "methods": [ "PUT" ],


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODLD-1040

Corrects Kong routing error seen in deploy as the POST was mis-attributed to the wrong path.